### PR TITLE
TCOTA-403 Fix for preventing duplicate participant records

### DIFF
--- a/src/main/java/edu/iu/terracotta/model/app/Participant.java
+++ b/src/main/java/edu/iu/terracotta/model/app/Participant.java
@@ -18,9 +18,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
 import java.sql.Timestamp;
 
-@Table(name = "terr_participant")
+@Table(name = "terr_participant", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "experiment_experiment_id", "lti_user_entity_user_id" }),
+        @UniqueConstraint(columnNames = { "experiment_experiment_id", "lti_membership_entity_membership_id" })
+})
 @Entity
 public class Participant extends BaseEntity {
     @Column(name = "participant_id", nullable = false)

--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
@@ -350,6 +350,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    @Transactional
     public void prepareParticipation(Long experimentId, SecuredInfo securedInfo) throws ParticipantNotUpdatedException {
 
         List<Participant> currentParticipantList =
@@ -456,6 +457,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    @Transactional
     public void setAllToNull(Long experimentId, SecuredInfo securedInfo) throws ParticipantNotUpdatedException {
         List<Participant> participants = allRepositories.participantRepository.findByExperiment_ExperimentId(experimentId);
         refreshParticipants(experimentId,securedInfo,participants);
@@ -467,6 +469,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    @Transactional
     public void setAllToTrue(Long experimentId, SecuredInfo securedInfo) throws ParticipantNotUpdatedException {
         List<Participant> participants = allRepositories.participantRepository.findByExperiment_ExperimentId(experimentId);
         refreshParticipants(experimentId,securedInfo,participants);
@@ -478,6 +481,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    @Transactional
     public void setAllToFalse(Long experimentId, SecuredInfo securedInfo) throws ParticipantNotUpdatedException {
         List<Participant> participants = allRepositories.participantRepository.findByExperiment_ExperimentId(experimentId);
         refreshParticipants(experimentId,securedInfo,participants);

--- a/src/main/javascript/src/views/design/ExperimentType.vue
+++ b/src/main/javascript/src/views/design/ExperimentType.vue
@@ -65,10 +65,10 @@ export default {
 			const step = "exposure_type"
 
 			this.updateExperiment(e)
-					.then(response => {
+					.then(async response => {
             if (typeof response?.status !== "undefined" && response?.status === 200) {
               // report the current step
-              this.reportStep({experimentId, step})
+              await this.reportStep({experimentId, step})
               if (this.experiment.exposureType==='BETWEEN' || this.experiment.exposureType==='WITHIN') {
                 this.$router.push({name:'ExperimentDesignDefaultCondition', params:{experiment: experimentId}})
               } else {

--- a/src/main/javascript/src/views/participation/SelectionMethod.vue
+++ b/src/main/javascript/src/views/participation/SelectionMethod.vue
@@ -53,10 +53,10 @@ export default {
 			const step = "participation_type"
 
 			this.updateExperiment(e)
-					.then(response => {
+					.then(async response => {
             if (typeof response?.status !== "undefined" && response?.status === 200) {
               // report the current step
-              this.reportStep({experimentId, step})
+              await this.reportStep({experimentId, step})
 
               // route based on participation type selection
               if (e.participationType==='CONSENT') {

--- a/src/main/javascript/src/views/participation/distribution/ParticipationDistribution.vue
+++ b/src/main/javascript/src/views/participation/distribution/ParticipationDistribution.vue
@@ -57,10 +57,10 @@ export default {
       const step = 'distribution_type'
 
       this.updateExperiment(e)
-        .then(response => {
+        .then(async response => {
           if (typeof response?.status !== 'undefined' && response?.status === 200) {
             // report the current step
-            this.reportStep({experimentId, step})
+            await this.reportStep({experimentId, step})
             // forward to correct path after selection
             if (this.experiment.distributionType==='EVEN') {
               this.$router.push({name:'ParticipationSummary', params:{experiment: experimentId}})

--- a/src/main/resources/db/changelog/2022.01/19-01-changelog.xml
+++ b/src/main/resources/db/changelog/2022.01/19-01-changelog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="machrist (generated)" id="1642628420725-1">
+        <addUniqueConstraint columnNames="experiment_experiment_id, lti_user_entity_user_id" constraintName="UK_TERR_PARTICIPANT_ON_EXPERIMENT_ID_AND_USER_ID" tableName="terr_participant"/>
+    </changeSet>
+    <changeSet author="machrist (generated)" id="1642628420725-2">
+        <addUniqueConstraint columnNames="experiment_experiment_id, lti_membership_entity_membership_id" constraintName="UK_TERR_PARTICIPANT_ON_EXPERIMENT_ID_AND_MEMBERSHIP_ID" tableName="terr_participant"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -45,4 +45,5 @@
     <include file="db/changelog/2021.12/26-02-changelog.xml"/>
     <include file="db/changelog/2021.12/26-03-changelog.xml"/>
     <include file="db/changelog/2021.12/26-04-changelog.xml"/>
+    <include file="db/changelog/2022.01/19-01-changelog.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR:

- adds unique constraint to prevent duplicate participant records
- makes sure that refreshParticipants executes in a transaction so that it doesn't only partially refresh the participants (all or nothing)
- UI waits now for step to be reported (participation_type step triggered refreshParticipants) before moving on, thus preventing simultaneous requests modifying participant data