### PR TITLE
TCOTA-434 Score consent submissions as 100% instead of a single point

### DIFF
--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
@@ -553,8 +553,10 @@ public class ParticipantServiceImpl implements ParticipantService {
         if (lineItem.isPresent()) {
             Score score = new Score();
             score.setUserId(participant.getLtiUserEntity().getUserKey());
+            // Score the consent submission as 100% and let the platform scale
+            // the grade to the max number of points.
             score.setScoreGiven("1.0");
-            score.setScoreMaximum(lineItem.get().getScoreMaximum());
+            score.setScoreMaximum("1.0");
             score.setActivityProgress("Completed");
             score.setGradingProgress("FullyGraded");
 


### PR DESCRIPTION
Instructors can change the number of points possible for a consent assignment
and Terracotta should just score consent submissions at 100%, giving the
student the max number of points.