### PR TITLE
Fix recipient submission matching for Canvas messaging rules

### DIFF
--- a/src/main/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImpl.java
@@ -155,7 +155,7 @@ public class MessageSendServiceImpl implements MessageSendService {
                             Collectors.toMap(
                                 Map.Entry::getKey,
                                 entry -> entry.getValue().stream()
-                                    .filter(lmsSubmission -> Strings.CI.equals(lmsSubmission.getUserLoginId(), participant.get().getLtiUserEntity().getEmail()))
+                                    .filter(lmsSubmission -> Strings.CI.equals(lmsSubmission.getUserId(), participant.get().getLtiUserEntity().getLmsUserId()))
                                     .toList()
                             )
                         );

--- a/src/main/java/edu/iu/terracotta/service/app/messaging/impl/preview/MessagePreviewServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/messaging/impl/preview/MessagePreviewServiceImpl.java
@@ -90,7 +90,7 @@ public class MessagePreviewServiceImpl implements MessagePreviewService {
                 Collectors.toMap(
                     Map.Entry::getKey,
                     entry -> entry.getValue().stream()
-                        .filter(lmsSubmission -> Strings.CI.equals(lmsSubmission.getUserLoginId(), participant.getLtiUserEntity().getEmail()))
+                        .filter(lmsSubmission -> Strings.CI.equals(lmsSubmission.getUserId(), participant.getLtiUserEntity().getLmsUserId()))
                         .toList()
                 )
             );


### PR DESCRIPTION
Matching submissions to a recipient by comparing Canvas's login_id against the participant's email silently drops the recipient's actual submission whenever those two values don't match, which is common on Canvas (SIS login_id is frequently not the email address). Match on LMS user ID instead, which is already resolved reliably and is always present on every submission row regardless of connector.