### PR TITLE
Add context_id to lms_user_batch_processing, set on batch start

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImpl.java
@@ -92,6 +92,7 @@ public class BrightspaceAdvantageMembershipServiceImpl implements AdvantageMembe
             LmsUserBatchProcessing lmsUserBatchProcessing = lmsUserBatchProcessingRepository.saveAndFlush(
                 LmsUserBatchProcessing.builder()
                     .batchId(batchId)
+                    .contextId(context.getContextId())
                     .status(LmsUserBatchStatus.IN_PROGRESS)
                     .build()
             );

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
@@ -509,7 +509,7 @@ public class CanvasApiClientImpl implements ApiClient {
         getUsersInCourseOptions.enrollmentType(enrollmentTypes);
 
         try {
-            getReader(apiUser, UserReaderExtended.class, lmsGetUsersInCourseOptions.getBatchSize()).getUsersInCourse(getUsersInCourseOptions, lmsGetUsersInCourseOptions.getBatchId());
+            getReader(apiUser, UserReaderExtended.class, lmsGetUsersInCourseOptions.getBatchSize()).getUsersInCourse(getUsersInCourseOptions, lmsGetUsersInCourseOptions.getBatchId(), lmsGetUsersInCourseOptions.getContextId());
         } catch (IOException | CanvasException ex) {
             throw new ApiException(String.format("Failed to get the list of users for Canvas course ID: [%s] for Canvas user ID: [%s]", getUsersInCourseOptions.getCourseId(), apiUser.getLmsUserId()), ex);
         }

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/UserReaderExtended.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/UserReaderExtended.java
@@ -11,6 +11,6 @@ import edu.ksu.canvas.requestOptions.GetUsersInCourseOptions;
 
 public interface UserReaderExtended extends CanvasReader<UserExtended, UserReaderExtended> {
 
-    void getUsersInCourse(GetUsersInCourseOptions getUsersInCourseOptions, UUID batchId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException;
+    void getUsersInCourse(GetUsersInCourseOptions getUsersInCourseOptions, UUID batchId, Long contextId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException;
 
 }

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/UserExtendedImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/UserExtendedImpl.java
@@ -48,30 +48,30 @@ public class UserExtendedImpl extends BaseImpl<UserExtended, UserReaderExtended,
     }
 
     @Override
-    public void getUsersInCourse(GetUsersInCourseOptions getUsersInCourseOptions, UUID batchId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException {
+    public void getUsersInCourse(GetUsersInCourseOptions getUsersInCourseOptions, UUID batchId, Long contextId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException {
         log.debug("Retrieving users in course {}", getUsersInCourseOptions.getCourseId());
         String url = buildCanvasUrl("courses/" + getUsersInCourseOptions.getCourseId() + "/users", getUsersInCourseOptions.getOptionsMap());
 
-        getListFromCanvas(url, batchId);
+        getListFromCanvas(url, batchId, contextId);
     }
 
-    private void getListFromCanvas(String url, UUID batchId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException {
+    private void getListFromCanvas(String url, UUID batchId, Long contextId) throws IOException, InvalidOauthTokenException, TerracottaConnectorException {
         Consumer<Response> consumer = null;
 
         if (responseCallback != null) {
             consumer = response -> responseCallback.accept(responseParser.parseToList(listType(), response));
         }
 
-        getFromCanvas(oauthToken, url, consumer, batchId);
+        getFromCanvas(oauthToken, url, consumer, batchId, contextId);
     }
 
-    private void getFromCanvas(@NotNull OauthToken oauthToken, @NotNull String url, Consumer<Response> callback, UUID batchId) throws InvalidOauthTokenException, IOException, TerracottaConnectorException {
+    private void getFromCanvas(@NotNull OauthToken oauthToken, @NotNull String url, Consumer<Response> callback, UUID batchId, Long contextId) throws InvalidOauthTokenException, IOException, TerracottaConnectorException {
         LmsUserBatchWriteService lmsUserBatchWriteService = ContextProvider.getBean(LmsUserBatchWriteService.class);
 
         // committed independently of whatever transaction the caller is running in, so progress
         // is visible immediately and durable even if a later page - or the caller's own
         // transaction - fails
-        lmsUserBatchWriteService.startBatch(batchId);
+        lmsUserBatchWriteService.startBatch(batchId, contextId);
 
         try {
             while (StringUtils.isNotBlank(url)) {

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImpl.java
@@ -83,7 +83,7 @@ public class CanvasAdvantageMembershipServiceImpl implements AdvantageMembership
                 CourseUsers.class
             );
 
-            lmsUserBatchWriteService.startBatch(batchId);
+            lmsUserBatchWriteService.startBatch(batchId, context.getContextId());
 
             if (!membershipGetResponse.getStatusCode().is2xxSuccessful()) {
                 String errorMessage = String.format("Can't get the membership for context ID: [%s]", context.getContextId());

--- a/src/main/java/edu/iu/terracotta/connectors/generic/dao/entity/lms/LmsUserBatchProcessing.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/dao/entity/lms/LmsUserBatchProcessing.java
@@ -36,6 +36,7 @@ public class LmsUserBatchProcessing extends BaseEntity {
     private LmsUserBatchStatus status;
 
     private UUID batchId;
+    private Long contextId;
     private String message;
 
 }

--- a/src/main/java/edu/iu/terracotta/connectors/generic/dao/model/lms/options/LmsGetUsersInCourseOptions.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/dao/model/lms/options/LmsGetUsersInCourseOptions.java
@@ -26,5 +26,6 @@ public class LmsGetUsersInCourseOptions {
     private List<EnrollmentType> enrollmentType;
     private Integer batchSize;
     private UUID batchId;
+    private Long contextId;
 
 }

--- a/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/LmsUserBatchWriteService.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/LmsUserBatchWriteService.java
@@ -14,7 +14,7 @@ import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatch;
  */
 public interface LmsUserBatchWriteService {
 
-    void startBatch(UUID batchId);
+    void startBatch(UUID batchId, Long contextId);
     void saveUsers(List<LmsUserBatch> usersToSave);
     void markFailed(UUID batchId, String message);
 

--- a/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImpl.java
@@ -25,10 +25,11 @@ public class LmsUserBatchWriteServiceImpl implements LmsUserBatchWriteService {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void startBatch(UUID batchId) {
+    public void startBatch(UUID batchId, Long contextId) {
         lmsUserBatchProcessingRepository.save(
             LmsUserBatchProcessing.builder()
                 .batchId(batchId)
+                .contextId(contextId)
                 .status(LmsUserBatchStatus.IN_PROGRESS)
                 .build()
         );

--- a/src/main/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImpl.java
@@ -92,6 +92,7 @@ public class OneEdTechAdvantageMembershipServiceImpl implements AdvantageMembers
             LmsUserBatchProcessing lmsUserBatchProcessing = lmsUserBatchProcessingRepository.saveAndFlush(
                 LmsUserBatchProcessing.builder()
                     .batchId(batchId)
+                    .contextId(context.getContextId())
                     .status(LmsUserBatchStatus.IN_PROGRESS)
                     .build()
             );

--- a/src/main/java/edu/iu/terracotta/service/app/async/impl/ParticipantAsyncServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/async/impl/ParticipantAsyncServiceImpl.java
@@ -99,6 +99,7 @@ public class ParticipantAsyncServiceImpl implements ParticipantAsyncService {
         apiClient.listUsersForCourse(
             LmsGetUsersInCourseOptions.builder()
                 .batchId(batchId)
+                .contextId(ltiContextEntity.getContextId())
                 .batchSize(batchSize)
                 .enrollmentState(Arrays.asList(EnrollmentState.ACTIVE, EnrollmentState.INVITED))
                 .enrollmentType(Arrays.asList(EnrollmentType.STUDENT))

--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
@@ -529,7 +529,9 @@ public class ParticipantServiceImpl implements ParticipantService {
     @Override
     @Transactional
     public LmsUserBatchStatusDto startPrepareParticipation(long experimentId, SecuredInfo securedInfo) throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
-        if (!isParticipantSyncStale(experimentId)) {
+        Experiment experiment = experimentRepository.findByExperimentId(experimentId);
+
+        if (!isParticipantSyncStale(experiment)) {
             prepareParticipation(experimentId, securedInfo);
 
             return LmsUserBatchStatusDto.builder()
@@ -543,6 +545,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         lmsUserBatchProcessingRepository.save(
             LmsUserBatchProcessing.builder()
                 .batchId(batchId)
+                .contextId(experiment == null ? null : experiment.getLtiContextEntity().getContextId())
                 .status(LmsUserBatchStatus.IN_PROGRESS)
                 .build()
         );
@@ -553,9 +556,7 @@ public class ParticipantServiceImpl implements ParticipantService {
             .build();
     }
 
-    private boolean isParticipantSyncStale(long experimentId) {
-        Experiment experiment = experimentRepository.findByExperimentId(experimentId);
-
+    private boolean isParticipantSyncStale(Experiment experiment) {
         if (experiment == null) {
             return true;
         }

--- a/src/main/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImpl.java
@@ -84,6 +84,7 @@ public class MessageSendServiceImpl implements MessageSendService {
         apiClient.listUsersForCourse(
             LmsGetUsersInCourseOptions.builder()
                 .batchId(batchId)
+                .contextId(message.getExperiment().getLtiContextEntity().getContextId())
                 .batchSize(batchSize)
                 .enrollmentState(Arrays.asList(EnrollmentState.ACTIVE, EnrollmentState.INVITED))
                 .enrollmentType(Arrays.asList(EnrollmentType.STUDENT))

--- a/src/main/resources/db/changelog/2026/07/31-01-changelog.xml
+++ b/src/main/resources/db/changelog/2026/07/31-01-changelog.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+    http://www.liquibase.org/xml/ns/pro
+    http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd"
+>
+  <changeSet author="rlong" id="1785552000-01">
+    <addColumn tableName="lms_user_batch_processing">
+      <column name="context_id" type="BIGINT"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -84,4 +84,5 @@
   <include file="db/changelog/2026/07/21-01-changelog.xml"/>
   <include file="db/changelog/2026/07/28-01-changelog.xml"/>
   <include file="db/changelog/2026/07/29-01-changelog.xml"/>
+  <include file="db/changelog/2026/07/31-01-changelog.xml"/>
 </databaseChangeLog>

--- a/src/test/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImplTest.java
@@ -102,6 +102,7 @@ public class BrightspaceAdvantageMembershipServiceImplTest extends BaseTest {
         verify(lmsUserBatchProcessingRepository).saveAndFlush(captor.capture());
         assertEquals(LmsUserBatchStatus.IN_PROGRESS, captor.getValue().getStatus());
         assertEquals(batchId, captor.getValue().getBatchId());
+        assertEquals(ltiContextEntity.getContextId(), captor.getValue().getContextId());
         verify(entityManager).flush();
         verify(entityManager).clear();
     }

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
@@ -863,7 +863,7 @@ public class CanvasApiClientImplTest extends BaseTest {
             result = canvasApiClientService.listUsersForCourse(options, ltiUserEntity);
         }
 
-        verify(userReaderExtended, times(1)).getUsersInCourse(any(), eq(options.getBatchId()));
+        verify(userReaderExtended, times(1)).getUsersInCourse(any(), eq(options.getBatchId()), eq(options.getContextId()));
         assertTrue(result.isEmpty());
     }
 
@@ -910,7 +910,7 @@ public class CanvasApiClientImplTest extends BaseTest {
             .batchSize(50)
             .batchId(UUID.randomUUID())
             .build();
-        doThrow(new IOException("fail")).when(userReaderExtended).getUsersInCourse(any(), any());
+        doThrow(new IOException("fail")).when(userReaderExtended).getUsersInCourse(any(), any(), any());
 
         try (MockedConstruction<CanvasApiFactoryExtended> _ = mockApiFactory()) {
             assertThrows(ApiException.class, () -> canvasApiClientService.listUsersForCourse(options, ltiUserEntity));

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/UserExtendedImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/UserExtendedImplTest.java
@@ -60,9 +60,9 @@ public class UserExtendedImplTest {
         when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
 
         UUID batchId = UUID.randomUUID();
-        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId);
+        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId, 1L);
 
-        verify(lmsUserBatchWriteService).startBatch(batchId);
+        verify(lmsUserBatchWriteService).startBatch(batchId, 1L);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class UserExtendedImplTest {
 
         when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
 
-        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID());
+        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID(), 1L);
 
         // all users from the page are saved in a single saveUsers() call, never one at a time
         verify(lmsUserBatchWriteService, times(1)).saveUsers(any());
@@ -99,7 +99,7 @@ public class UserExtendedImplTest {
             .thenReturn(pageOne)
             .thenReturn(pageTwo);
 
-        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID());
+        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID(), 1L);
 
         // one saveUsers() per page fetched, committed independently of the caller's transaction
         verify(lmsUserBatchWriteService, times(2)).saveUsers(any());
@@ -114,7 +114,7 @@ public class UserExtendedImplTest {
         when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
 
         UUID batchId = UUID.randomUUID();
-        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId);
+        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId, 1L);
 
         verify(lmsUserBatchWriteService).markFailed(eq(batchId), any());
         verify(lmsUserBatchWriteService, never()).saveUsers(any());
@@ -132,7 +132,7 @@ public class UserExtendedImplTest {
 
         assertThrows(
             InvalidOauthTokenException.class,
-            () -> userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId)
+            () -> userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), batchId, 1L)
         );
 
         verify(lmsUserBatchWriteService).markFailed(eq(batchId), any());
@@ -148,7 +148,7 @@ public class UserExtendedImplTest {
 
         when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
 
-        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID());
+        userExtended.getUsersInCourse(new GetUsersInCourseOptions("1"), UUID.randomUUID(), 1L);
 
         verify(lmsUserBatchWriteService, times(1)).saveUsers(List.<LmsUserBatch>of());
     }

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImplTest.java
@@ -90,7 +90,7 @@ public class CanvasAdvantageMembershipServiceImplTest extends BaseTest {
         CourseUsers ret = canvasAdvantageMembershipService.callMembershipService(ltiToken, ltiContextEntity, batchId, true);
 
         assertNull(ret);
-        verify(lmsUserBatchWriteService).startBatch(batchId);
+        verify(lmsUserBatchWriteService).startBatch(batchId, 1L);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class CanvasAdvantageMembershipServiceImplTest extends BaseTest {
 
         assertThrows(ConnectionException.class, () -> canvasAdvantageMembershipService.callMembershipService(ltiToken, ltiContextEntity, batchId, true));
 
-        verify(lmsUserBatchWriteService).startBatch(batchId);
+        verify(lmsUserBatchWriteService).startBatch(batchId, 1L);
         // marked failed exactly once - not once explicitly and once more via the generic catch block
         verify(lmsUserBatchWriteService, times(1)).markFailed(eq(batchId), anyString());
     }

--- a/src/test/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImplTest.java
@@ -40,11 +40,12 @@ public class LmsUserBatchWriteServiceImplTest {
     public void testStartBatchSavesInProgressRecord() {
         UUID batchId = UUID.randomUUID();
 
-        lmsUserBatchWriteService.startBatch(batchId);
+        lmsUserBatchWriteService.startBatch(batchId, 123L);
 
         ArgumentCaptor<LmsUserBatchProcessing> captor = ArgumentCaptor.forClass(LmsUserBatchProcessing.class);
         verify(lmsUserBatchProcessingRepository).save(captor.capture());
         assertEquals(batchId, captor.getValue().getBatchId());
+        assertEquals(123L, captor.getValue().getContextId());
         assertEquals(LmsUserBatchStatus.IN_PROGRESS, captor.getValue().getStatus());
     }
 

--- a/src/test/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImplTest.java
@@ -105,6 +105,19 @@ public class OneEdTechAdvantageMembershipServiceImplTest extends BaseTest {
     }
 
     @Test
+    public void testCallMembershipServiceSuccessCreatesInProgressRecordWithContextId() throws ConnectionException, TerracottaConnectorException {
+        UUID batchId = UUID.randomUUID();
+
+        oneEdTechAdvantageMembershipService.callMembershipService(ltiToken, ltiContextEntity, batchId, true);
+
+        ArgumentCaptor<LmsUserBatchProcessing> captor = ArgumentCaptor.forClass(LmsUserBatchProcessing.class);
+        verify(lmsUserBatchProcessingRepository).saveAndFlush(captor.capture());
+        assertEquals(LmsUserBatchStatus.IN_PROGRESS, captor.getValue().getStatus());
+        assertEquals(batchId, captor.getValue().getBatchId());
+        assertEquals(ltiContextEntity.getContextId(), captor.getValue().getContextId());
+    }
+
+    @Test
     public void testCallMembershipServiceOnlyStudentsTrueFiltersNonLearners() throws ConnectionException, TerracottaConnectorException {
         CourseUser learner = CourseUser.builder().userId("learnerId").name("Learner One").email("learner@example.com").roles(List.of(Roles.LEARNER)).build();
         CourseUser instructor = CourseUser.builder().userId("instructorId").name("Instructor One").email("instructor@example.com").roles(List.of(Roles.INSTRUCTOR)).build();

--- a/src/test/java/edu/iu/terracotta/service/app/async/impl/ParticipantAsyncServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/async/impl/ParticipantAsyncServiceImplTest.java
@@ -29,6 +29,7 @@ import edu.iu.terracotta.base.BaseTest;
 import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchEmailProjection;
 import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchProcessing;
 import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchStatus;
+import edu.iu.terracotta.connectors.generic.dao.model.lms.options.LmsGetUsersInCourseOptions;
 import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchProcessingRepository;
 import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchRepository;
 import edu.iu.terracotta.dao.entity.projection.LmsParticipantSummary;
@@ -115,7 +116,9 @@ public class ParticipantAsyncServiceImplTest extends BaseTest {
 
         participantAsyncService.updateParticipantData(securedInfo);
 
-        verify(apiClient).listUsersForCourse(any(), eq(ltiUserEntity));
+        ArgumentCaptor<LmsGetUsersInCourseOptions> optionsCaptor = ArgumentCaptor.forClass(LmsGetUsersInCourseOptions.class);
+        verify(apiClient).listUsersForCourse(optionsCaptor.capture(), eq(ltiUserEntity));
+        assertEquals(Long.valueOf(securedInfo.getContextId()), optionsCaptor.getValue().getContextId());
         verify(lmsUserBatchAsyncService).processed(any(UUID.class), anyString());
         verify(lmsUserBatchAsyncService, never()).success(any(UUID.class));
     }

--- a/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImplTest.java
@@ -828,6 +828,7 @@ public class ParticipantServiceImplTest extends BaseTest {
         verify(lmsUserBatchProcessingRepository).save(captor.capture());
         assertEquals(result.getBatchId(), captor.getValue().getBatchId());
         assertEquals(LmsUserBatchStatus.IN_PROGRESS, captor.getValue().getStatus());
+        assertEquals(Long.valueOf(ltiContextEntity.getContextId()), captor.getValue().getContextId());
         verify(participantService, never()).prepareParticipation(anyLong(), any());
     }
 

--- a/src/test/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/messaging/impl/message/MessageSendServiceImplTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchEmailProj
 import edu.iu.terracotta.connectors.generic.dao.entity.lti.LtiContextEntity;
 import edu.iu.terracotta.connectors.generic.dao.entity.lti.LtiUserEntity;
 import edu.iu.terracotta.connectors.generic.dao.entity.lti.PlatformDeployment;
+import edu.iu.terracotta.connectors.generic.dao.model.lms.options.LmsGetUsersInCourseOptions;
 import edu.iu.terracotta.connectors.generic.dao.model.lms.LmsSubmission;
 import edu.iu.terracotta.connectors.generic.dao.model.lms.LmsUser;
 import edu.iu.terracotta.connectors.generic.exceptions.ApiException;
@@ -151,7 +153,10 @@ public class MessageSendServiceImplTest extends BaseTest {
 
         // the LMS roster sync kicks off unconditionally before the participants check, so it still runs
         assertTrue(recipients.isEmpty());
-        verify(apiClient).listUsersForCourse(any(), any(LtiUserEntity.class));
+
+        ArgumentCaptor<LmsGetUsersInCourseOptions> optionsCaptor = ArgumentCaptor.forClass(LmsGetUsersInCourseOptions.class);
+        verify(apiClient).listUsersForCourse(optionsCaptor.capture(), any(LtiUserEntity.class));
+        assertEquals(Long.valueOf(message.getExperiment().getLtiContextEntity().getContextId()), optionsCaptor.getValue().getContextId());
     }
 
     @Test


### PR DESCRIPTION
Threads the LTI context ID through every "batch start" call site so progress/status records can be tied back to the course they came from, instead of only being identifiable by batch UUID.