### PR TITLE
Fix new experiments never syncing participants when their course was …

### DIFF
--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
@@ -391,7 +391,15 @@ public class ParticipantServiceImpl implements ParticipantService {
             throw new ExperimentNotMatchingException(TextConstants.EXPERIMENT_NOT_MATCHING);
         }
 
-        if (isParticipantSyncFresh(experiment.getLtiContextEntity(), batchId)) {
+        // the freshness checks below are keyed by LTI context (course), not experiment, since the
+        // LMS roster itself is a property of the course - but Participant rows are created
+        // per-experiment (see refreshParticipants -> syncParticipantsPage). A brand-new
+        // experiment sharing a course with another, already-synced experiment must still get its
+        // own first sync regardless of how "fresh" the course is, or it silently keeps zero
+        // participants until the course-level throttle window happens to expire.
+        boolean neverSyncedForThisExperiment = participantRepository.countByExperiment_ExperimentId(experimentId) == 0;
+
+        if (!neverSyncedForThisExperiment && isParticipantSyncFresh(experiment.getLtiContextEntity(), batchId)) {
             return;
         }
 
@@ -405,7 +413,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         // simply never reaches the write that marks it synced, leaving it correctly untouched.
         LtiContextEntity ltiContextEntity = ltiContextRepository.findByContextIdForUpdate(experiment.getLtiContextEntity().getContextId());
 
-        if (isParticipantSyncFresh(ltiContextEntity, batchId)) {
+        if (!neverSyncedForThisExperiment && isParticipantSyncFresh(ltiContextEntity, batchId)) {
             return;
         }
 

--- a/src/main/javascript/src/services/participants.service.js
+++ b/src/main/javascript/src/services/participants.service.js
@@ -82,6 +82,12 @@ function handleResponse(response) {
     .then((text) => {
       const data = (text && isJson(text)) ? JSON.parse(text) : text
 
+      if (response.status === 204) {
+        // no participants exist yet for this experiment - a genuine empty result, not a
+        // failure, but the body is empty so there's nothing for JSON.parse to return an array
+        return []
+      }
+
       if (!response || !response.ok) {
         if (
           response.status === 402 ||

--- a/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImplTest.java
@@ -751,6 +751,9 @@ public class ParticipantServiceImplTest extends BaseTest {
     @Test
     public void testRefreshParticipantsIfStaleSkipsWhenRecentSyncAttemptExistsForContext() throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         when(ltiContextEntity.getLastParticipantSync()).thenReturn(null);
+        // this experiment already has participants, so the course-level freshness check applies
+        // instead of being bypassed as a first-ever sync
+        when(participantRepository.countByExperiment_ExperimentId(1L)).thenReturn(5L);
 
         LmsUserBatchProcessing recentAttempt = new LmsUserBatchProcessing();
         recentAttempt.setCreatedAt(Timestamp.from(Instant.now()));
@@ -813,9 +816,26 @@ public class ParticipantServiceImplTest extends BaseTest {
         verify(participantService).refreshParticipants(1L, batchId);
     }
 
+    // a brand-new experiment sharing a course with another, already-synced experiment must still
+    // get its own first sync - last_participant_sync being "fresh" describes the course's LMS
+    // roster, not whether this specific experiment has any Participant rows yet
+    @Test
+    public void testRefreshParticipantsIfStaleRefreshesNewExperimentDespiteFreshCourseSync() throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
+        when(ltiContextEntity.getLastParticipantSync()).thenReturn(Instant.now());
+        when(participantRepository.countByExperiment_ExperimentId(1L)).thenReturn(0L);
+        doNothing().when(participantService).refreshParticipants(anyLong(), any(UUID.class));
+
+        participantService.refreshParticipantsIfStale(1L);
+
+        verify(participantService).refreshParticipants(eq(1L), any(UUID.class));
+    }
+
     @Test
     public void testRefreshParticipantsIfStaleSkipsWhenRecentlySynced() throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         when(ltiContextEntity.getLastParticipantSync()).thenReturn(Instant.now());
+        // this experiment already has participants, so the course-level freshness check applies
+        // instead of being bypassed as a first-ever sync
+        when(participantRepository.countByExperiment_ExperimentId(1L)).thenReturn(5L);
 
         participantService.refreshParticipantsIfStale(1L);
 
@@ -912,6 +932,9 @@ public class ParticipantServiceImplTest extends BaseTest {
         when(participantRepository.findByExperiment_ExperimentId(anyLong(), any())).thenReturn(List.of(participant), Collections.emptyList());
         when(participant.getSource()).thenReturn(ParticipationTypes.AUTO);
         when(ltiContextEntity.getLastParticipantSync()).thenReturn(Instant.now());
+        // this experiment already has participants, so the course-level freshness check applies
+        // instead of being bypassed as a first-ever sync
+        when(participantRepository.countByExperiment_ExperimentId(1L)).thenReturn(5L);
 
         assertDoesNotThrow(() -> participantService.prepareParticipation(1L, securedInfo, UUID.randomUUID()));
 


### PR DESCRIPTION
…recently synced

refreshParticipantsIfStale throttles by LTI context (course), since the LMS roster is a course-wide property - but Participant rows are created per-experiment. A brand-new experiment sharing a course with another, already-synced experiment inherited that course's "fresh" timestamp and had its own first sync silently skipped, leaving it with zero participants until the throttle window (5 min debounce, or up to a week for large courses) happened to expire. Bypass the freshness check whenever this specific experiment has no participants of its own yet.

Also fix handleResponse in participants.service.js: it didn't special-case 204 No Content (a genuine "zero participants" response), so the empty body fell through to returning the raw Response object instead of []. That object then correctly tripped the store's non-array guard, misreporting a real empty result as a fetch failure.