### PR TITLE
Fix experiment data export failing on Canvas "not authorized" for mul…

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
@@ -429,6 +429,11 @@ public class CanvasApiClientImpl implements ApiClient {
     public List<LmsSubmission> listSubmissionsForMultipleAssignments(LtiUserEntity apiUser, String canvasCourseId, List<String> canvasAssignmentIds) throws ApiException, IOException, TerracottaConnectorException {
         GetSubmissionsOptionsExtended submissionsOptions = new GetSubmissionsOptionsExtended(canvasCourseId, canvasAssignmentIds);
         submissionsOptions.includes(Collections.singletonList(GetSubmissionsOptions.Include.USER));
+        // without student_ids[], Canvas defaults to the calling user's own submission - since the
+        // instructor calling this isn't a student in the course, Canvas rejects that as
+        // unauthorized rather than returning an empty list (see the single-assignment
+        // listSubmissions above, which already sets this)
+        submissionsOptions.userIds(List.of(GetSubmissionsOptionsExtended.UserId.ALL.toString()));
 
         try {
             return castList(

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
@@ -35,6 +35,7 @@ import edu.iu.terracotta.connectors.canvas.dao.model.extended.AssignmentExtended
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.ConversationExtended;
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.FileExtended;
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.FolderExtended;
+import edu.iu.terracotta.connectors.canvas.dao.model.extended.options.GetSubmissionsOptionsExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.AssignmentReaderExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.AssignmentWriterExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.ConversationReaderExtended;
@@ -739,6 +740,24 @@ public class CanvasApiClientImplTest extends BaseTest {
         }
 
         assertEquals(1, result.size());
+    }
+
+    // without student_ids[]=all, Canvas defaults to the calling user's own submission and
+    // rejects the request as unauthorized for an instructor who isn't enrolled as a student -
+    // see the "User is not authorized to perform this action" production incident this fixes
+    @Test
+    void testListSubmissionsForMultipleAssignmentsRequestsAllStudentIds() throws Exception {
+        when(submissionReaderExtended.listSubmissionsForMultipleAssignments(any())).thenReturn(List.of(canvasSubmissionExtended));
+        when(canvasSubmissionExtended.from()).thenReturn(lmsSubmission);
+
+        ArgumentCaptor<GetSubmissionsOptionsExtended> optionsCaptor = ArgumentCaptor.forClass(GetSubmissionsOptionsExtended.class);
+
+        try (MockedConstruction<CanvasApiFactoryExtended> _ = mockApiFactory()) {
+            canvasApiClientService.listSubmissionsForMultipleAssignments(ltiUserEntity, "course1", List.of("1", "2"));
+        }
+
+        verify(submissionReaderExtended).listSubmissionsForMultipleAssignments(optionsCaptor.capture());
+        assertEquals(List.of("all"), optionsCaptor.getValue().getOptionsMap().get("student_ids[]"));
     }
 
     @Test


### PR DESCRIPTION
…ti-assignment submissions

listSubmissionsForMultipleAssignments never set student_ids[] on the outgoing request, unlike the single-assignment listSubmissions, which already sends student_ids[]=all. Per Canvas's API, omitting student_ids[] defaults the request to "submissions for the calling user" - since the instructor triggering the export isn't enrolled as a student, Canvas rejected that as unauthorized instead of returning an empty list, failing the whole outcomes CSV export.