### PR TITLE
Add scheduled cleanup for LMS user batches stuck IN_PROGRESS

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/generic/dao/repository/lms/LmsUserBatchProcessingRepository.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/dao/repository/lms/LmsUserBatchProcessingRepository.java
@@ -1,5 +1,7 @@
 package edu.iu.terracotta.connectors.generic.dao.repository.lms;
 
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,6 +22,10 @@ public interface LmsUserBatchProcessingRepository extends JpaRepository<LmsUserB
     // excludes the batch currently being processed - used by the debounce check so a batch's own
     // just-created IN_PROGRESS row doesn't make it look like the context was already synced
     Optional<LmsUserBatchProcessing> findFirstByContextIdAndBatchIdNotOrderByCreatedAtDesc(Long contextId, UUID batchId);
+    // a row left in this status past the given threshold means whatever was processing it (an
+    // @Async task) never reached its own completion code - e.g. an app restart/crash mid-sync, or
+    // an uncaught Error - see LmsUserBatchCleanerSchedulerServiceImpl
+    List<LmsUserBatchProcessing> findAllByStatusAndUpdatedAtBefore(LmsUserBatchStatus status, Timestamp threshold);
 
     /**
      * More than one writer can race to record the same batchId's terminal status (e.g. the LMS

--- a/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/LmsUserBatchCleanerSchedulerService.java
+++ b/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/LmsUserBatchCleanerSchedulerService.java
@@ -1,0 +1,11 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner;
+
+import java.util.Optional;
+
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleResult;
+
+public interface LmsUserBatchCleanerSchedulerService {
+
+    Optional<LmsUserBatchCleanerScheduleResult> cleanup(int staleTtlMinutes);
+
+}

--- a/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/configuration/LmsUserBatchCleanerSchedulerRunner.java
+++ b/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/configuration/LmsUserBatchCleanerSchedulerRunner.java
@@ -1,0 +1,89 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.configuration;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
+
+import edu.iu.terracotta.exceptions.scheduledtask.ScheduledTaskNotFound;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.LmsUserBatchCleanerSchedulerService;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleResult;
+import edu.iu.terracotta.service.app.ScheduledTaskService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@SuppressWarnings({"PMD.GuardLogStatement"})
+public class LmsUserBatchCleanerSchedulerRunner {
+
+    public static final String TASK_NAME = "cleanup_stale_lms_user_batches";
+    public static final TaskDescriptor<Void> LMS_USER_BATCH_CLEANER_TASK = TaskDescriptor.of(TASK_NAME);
+
+    private final ScheduledTaskService scheduledTaskService;
+
+    @Value("${lms.user.batch.cleaner.scheduler.enabled:false}")
+    private boolean enabled;
+
+    @Value("${lms.user.batch.cleaner.scheduler.check.interval.minutes:60}")
+    private int interval;
+
+    @Value("${lms.user.batch.cleaner.scheduler.stale.ttl.minutes:60}")
+    private int staleTtlMinutes;
+
+    @Bean
+    Task<Void> lmsUserBatchCleanerTask(LmsUserBatchCleanerSchedulerService lmsUserBatchCleanerSchedulerService) {
+        try {
+            // reset task in case of dirty server shutdown
+            scheduledTaskService.resetTask(TASK_NAME);
+        } catch (ScheduledTaskNotFound e) {
+            log.error(e.getMessage());
+        }
+
+        if (!enabled) {
+            // not enabled; create one-time task to log message
+            return Tasks.oneTime(LMS_USER_BATCH_CLEANER_TASK)
+                .execute(
+                    (instance, ctx) -> {
+                        log.info("LMS user batch cleaner task [{}] is not enabled.", LMS_USER_BATCH_CLEANER_TASK.getTaskName());
+                    }
+                );
+        }
+
+        log.info("Creating LMS user batch cleaner task [{}]", LMS_USER_BATCH_CLEANER_TASK.getTaskName());
+
+        return Tasks.recurring(LMS_USER_BATCH_CLEANER_TASK, Schedules.fixedDelay(Duration.ofMinutes(interval)))
+            .onDeadExecutionRevive()
+            .execute(
+                (instance, ctx) -> {
+                    Optional<LmsUserBatchCleanerScheduleResult> results = lmsUserBatchCleanerSchedulerService.cleanup(staleTtlMinutes);
+
+                    if (results.isEmpty()) {
+                        return;
+                    }
+
+                    try {
+                        log.info(
+                            "Task [{}] ran. Cleaned up stale LMS user batches: [{}]",
+                            TASK_NAME,
+                            JsonMapper.builder()
+                                .build()
+                                .writeValueAsString(results.get())
+                        );
+                    } catch (JacksonException e) {
+                        log.error("Error occurred writing value to JSON", e);
+                    }
+                }
+            );
+    }
+}

--- a/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/impl/LmsUserBatchCleanerSchedulerServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/impl/LmsUserBatchCleanerSchedulerServiceImpl.java
@@ -1,0 +1,92 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.impl;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchProcessing;
+import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchStatus;
+import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchProcessingRepository;
+import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchRepository;
+import edu.iu.terracotta.connectors.generic.service.lms.LmsUserBatchWriteService;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.LmsUserBatchCleanerSchedulerService;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleMessage;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings({"PMD.GuardLogStatement"})
+public class LmsUserBatchCleanerSchedulerServiceImpl implements LmsUserBatchCleanerSchedulerService {
+
+    private final LmsUserBatchProcessingRepository lmsUserBatchProcessingRepository;
+    private final LmsUserBatchRepository lmsUserBatchRepository;
+    private final LmsUserBatchWriteService lmsUserBatchWriteService;
+
+    @Override
+    public Optional<LmsUserBatchCleanerScheduleResult> cleanup(int staleTtlMinutes) {
+        // a row still IN_PROGRESS past this threshold means whatever @Async task was processing
+        // it never reached its own completion code - e.g. an app restart/crash mid-sync, or an
+        // uncaught Error - so it never will on its own
+        List<LmsUserBatchProcessing> staleBatches = lmsUserBatchProcessingRepository.findAllByStatusAndUpdatedAtBefore(
+            LmsUserBatchStatus.IN_PROGRESS,
+            Timestamp.from(Instant.now().minus(Duration.ofMinutes(staleTtlMinutes)))
+        );
+
+        if (CollectionUtils.isEmpty(staleBatches)) {
+            // no stale batches exist; exit
+            return Optional.empty();
+        }
+
+        return Optional.of(
+            LmsUserBatchCleanerScheduleResult.builder()
+                .processed(
+                    staleBatches.stream()
+                        .map(
+                            staleBatch -> {
+                                String error = null;
+                                long deletedStagedRows = 0;
+
+                                try {
+                                    // count before deleting - staged rows this abandoned sync
+                                    // already wrote to the LMS but never got to convert into
+                                    // real Participant/LtiUser records or clean up itself
+                                    deletedStagedRows = lmsUserBatchRepository.countByBatchId(staleBatch.getBatchId());
+                                    lmsUserBatchRepository.deleteByBatchId(staleBatch.getBatchId());
+                                    lmsUserBatchWriteService.markFailed(
+                                        staleBatch.getBatchId(),
+                                        String.format(
+                                            "Sync abandoned: stuck in IN_PROGRESS for over [%d] minutes with no further progress - likely interrupted by an application restart, crash, or rejected task submission.",
+                                            staleTtlMinutes
+                                        )
+                                    );
+                                } catch (Exception e) {
+                                    log.warn("Error cleaning up stale LMS user batch with batch ID: [{}]: {}", staleBatch.getBatchId(), e.getMessage());
+                                    error = e.getMessage();
+                                }
+
+                                return LmsUserBatchCleanerScheduleMessage.builder()
+                                    .id(staleBatch.getId())
+                                    .batchId(staleBatch.getBatchId())
+                                    .contextId(staleBatch.getContextId())
+                                    .deletedStagedRows(deletedStagedRows)
+                                    .cleanedUpAt(Timestamp.from(Instant.now()))
+                                    .errors(StringUtils.isEmpty(error) ? null : List.of(error))
+                                    .build();
+                            }
+                        )
+                        .toList()
+                )
+                .build()
+        );
+    }
+
+}

--- a/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/model/LmsUserBatchCleanerScheduleMessage.java
+++ b/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/model/LmsUserBatchCleanerScheduleMessage.java
@@ -1,0 +1,23 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.model;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class LmsUserBatchCleanerScheduleMessage {
+
+    private long id;
+    private UUID batchId;
+    private Long contextId;
+    private long deletedStagedRows;
+    private Timestamp cleanedUpAt;
+    private List<String> errors;
+
+}

--- a/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/model/LmsUserBatchCleanerScheduleResult.java
+++ b/src/main/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/model/LmsUserBatchCleanerScheduleResult.java
@@ -1,0 +1,16 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class LmsUserBatchCleanerScheduleResult {
+
+    private List<LmsUserBatchCleanerScheduleMessage> processed;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -381,3 +381,19 @@ api:
         expiration:
           ttl:
             days: 30
+
+# LMS user batch cleaner scheduler - catches lms_user_batch_processing rows left IN_PROGRESS by
+# an @Async sync task that never reached its own completion code (app restart/crash mid-sync, an
+# uncaught Error, etc.), marks them FAILED, and deletes their orphaned lms_user_batch staging rows
+lms:
+  user:
+    batch:
+      cleaner:
+        scheduler:
+          enabled: true
+          check:
+            interval:
+              minutes: 60
+          stale:
+            ttl:
+              minutes: 60

--- a/src/test/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/configuration/LmsUserBatchCleanerSchedulerRunnerTest.java
+++ b/src/test/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/configuration/LmsUserBatchCleanerSchedulerRunnerTest.java
@@ -1,0 +1,111 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+
+import edu.iu.terracotta.exceptions.scheduledtask.ScheduledTaskNotFound;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.LmsUserBatchCleanerSchedulerService;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleMessage;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleResult;
+import edu.iu.terracotta.service.app.ScheduledTaskService;
+
+public class LmsUserBatchCleanerSchedulerRunnerTest {
+
+    @Mock private ScheduledTaskService scheduledTaskService;
+    @Mock private LmsUserBatchCleanerSchedulerService lmsUserBatchCleanerSchedulerService;
+
+    private LmsUserBatchCleanerSchedulerRunner lmsUserBatchCleanerSchedulerRunner;
+
+    @BeforeEach
+    public void beforeEach() {
+        MockitoAnnotations.openMocks(this);
+
+        lmsUserBatchCleanerSchedulerRunner = new LmsUserBatchCleanerSchedulerRunner(scheduledTaskService);
+    }
+
+    @Test
+    public void testLmsUserBatchCleanerTaskResetTaskSucceeds() throws ScheduledTaskNotFound {
+        Task<Void> task = lmsUserBatchCleanerSchedulerRunner.lmsUserBatchCleanerTask(lmsUserBatchCleanerSchedulerService);
+
+        assertNotNull(task);
+        verify(scheduledTaskService).resetTask(LmsUserBatchCleanerSchedulerRunner.TASK_NAME);
+    }
+
+    @Test
+    public void testLmsUserBatchCleanerTaskResetTaskNotFoundIsSwallowed() throws ScheduledTaskNotFound {
+        doThrow(new ScheduledTaskNotFound("not found")).when(scheduledTaskService).resetTask(LmsUserBatchCleanerSchedulerRunner.TASK_NAME);
+
+        Task<Void> task = assertDoesNotThrow(() -> lmsUserBatchCleanerSchedulerRunner.lmsUserBatchCleanerTask(lmsUserBatchCleanerSchedulerService));
+
+        assertNotNull(task);
+    }
+
+    @Test
+    public void testLmsUserBatchCleanerTaskDisabledDoesNotInvokeService() {
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "enabled", false);
+
+        Task<Void> task = lmsUserBatchCleanerSchedulerRunner.lmsUserBatchCleanerTask(lmsUserBatchCleanerSchedulerService);
+
+        // ExecutionContext is never read by the runner's lambdas; null is safe here.
+        task.execute(new TaskInstance<Void>(LmsUserBatchCleanerSchedulerRunner.TASK_NAME, "test-id"), null);
+
+        verifyNoInteractions(lmsUserBatchCleanerSchedulerService);
+    }
+
+    @Test
+    public void testLmsUserBatchCleanerTaskEnabledInvokesCleanupWhenResultEmpty() {
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "enabled", true);
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "interval", 60);
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "staleTtlMinutes", 90);
+
+        when(lmsUserBatchCleanerSchedulerService.cleanup(90)).thenReturn(Optional.empty());
+
+        Task<Void> task = lmsUserBatchCleanerSchedulerRunner.lmsUserBatchCleanerTask(lmsUserBatchCleanerSchedulerService);
+
+        task.execute(new TaskInstance<Void>(LmsUserBatchCleanerSchedulerRunner.TASK_NAME, "test-id"), null);
+
+        verify(lmsUserBatchCleanerSchedulerService).cleanup(90);
+    }
+
+    @Test
+    public void testLmsUserBatchCleanerTaskEnabledLogsResultWithoutThrowing() {
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "enabled", true);
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "interval", 60);
+        ReflectionTestUtils.setField(lmsUserBatchCleanerSchedulerRunner, "staleTtlMinutes", 60);
+
+        LmsUserBatchCleanerScheduleResult scheduleResult = LmsUserBatchCleanerScheduleResult.builder()
+            .processed(
+                List.of(
+                    LmsUserBatchCleanerScheduleMessage.builder().id(1L).batchId(UUID.randomUUID()).contextId(42L).deletedStagedRows(5L).build(),
+                    LmsUserBatchCleanerScheduleMessage.builder().id(2L).batchId(UUID.randomUUID()).contextId(43L).deletedStagedRows(0L).build()
+                )
+            )
+            .build();
+
+        when(lmsUserBatchCleanerSchedulerService.cleanup(60)).thenReturn(Optional.of(scheduleResult));
+
+        Task<Void> task = lmsUserBatchCleanerSchedulerRunner.lmsUserBatchCleanerTask(lmsUserBatchCleanerSchedulerService);
+
+        assertDoesNotThrow(() -> task.execute(new TaskInstance<Void>(LmsUserBatchCleanerSchedulerRunner.TASK_NAME, "test-id"), null));
+
+        verify(lmsUserBatchCleanerSchedulerService).cleanup(60);
+    }
+
+}

--- a/src/test/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/impl/LmsUserBatchCleanerSchedulerServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/runner/lmsuserbatchcleaner/impl/LmsUserBatchCleanerSchedulerServiceImplTest.java
@@ -1,0 +1,141 @@
+package edu.iu.terracotta.runner.lmsuserbatchcleaner.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchProcessing;
+import edu.iu.terracotta.connectors.generic.dao.entity.lms.LmsUserBatchStatus;
+import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchProcessingRepository;
+import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchRepository;
+import edu.iu.terracotta.connectors.generic.service.lms.LmsUserBatchWriteService;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleMessage;
+import edu.iu.terracotta.runner.lmsuserbatchcleaner.model.LmsUserBatchCleanerScheduleResult;
+
+public class LmsUserBatchCleanerSchedulerServiceImplTest {
+
+    private static final int STALE_TTL_MINUTES = 60;
+
+    @Mock private LmsUserBatchProcessingRepository lmsUserBatchProcessingRepository;
+    @Mock private LmsUserBatchRepository lmsUserBatchRepository;
+    @Mock private LmsUserBatchWriteService lmsUserBatchWriteService;
+
+    private LmsUserBatchCleanerSchedulerServiceImpl lmsUserBatchCleanerSchedulerService;
+
+    @BeforeEach
+    public void beforeEach() {
+        MockitoAnnotations.openMocks(this);
+
+        lmsUserBatchCleanerSchedulerService = new LmsUserBatchCleanerSchedulerServiceImpl(
+            lmsUserBatchProcessingRepository,
+            lmsUserBatchRepository,
+            lmsUserBatchWriteService
+        );
+    }
+
+    @Test
+    public void testCleanupNoStaleBatchesFound() {
+        when(lmsUserBatchProcessingRepository.findAllByStatusAndUpdatedAtBefore(eq(LmsUserBatchStatus.IN_PROGRESS), any(Timestamp.class))).thenReturn(List.of());
+
+        Optional<LmsUserBatchCleanerScheduleResult> result = lmsUserBatchCleanerSchedulerService.cleanup(STALE_TTL_MINUTES);
+
+        assertTrue(result.isEmpty());
+        verify(lmsUserBatchWriteService, never()).markFailed(any(UUID.class), anyString());
+    }
+
+    @Test
+    public void testCleanupMarksStaleBatchFailedAndDeletesStagedRows() {
+        LmsUserBatchProcessing staleBatch = buildStaleBatch(1L, UUID.randomUUID(), 42L);
+
+        when(lmsUserBatchProcessingRepository.findAllByStatusAndUpdatedAtBefore(eq(LmsUserBatchStatus.IN_PROGRESS), any(Timestamp.class))).thenReturn(List.of(staleBatch));
+        when(lmsUserBatchRepository.countByBatchId(staleBatch.getBatchId())).thenReturn(5L);
+
+        Optional<LmsUserBatchCleanerScheduleResult> result = lmsUserBatchCleanerSchedulerService.cleanup(STALE_TTL_MINUTES);
+
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().getProcessed().size());
+
+        LmsUserBatchCleanerScheduleMessage message = result.get().getProcessed().get(0);
+
+        assertEquals(staleBatch.getId(), message.getId());
+        assertEquals(staleBatch.getBatchId(), message.getBatchId());
+        assertEquals(staleBatch.getContextId(), message.getContextId());
+        assertEquals(5, message.getDeletedStagedRows());
+        assertNotNull(message.getCleanedUpAt());
+        assertNull(message.getErrors());
+
+        verify(lmsUserBatchRepository).deleteByBatchId(staleBatch.getBatchId());
+        verify(lmsUserBatchWriteService).markFailed(eq(staleBatch.getBatchId()), anyString());
+    }
+
+    @Test
+    public void testCleanupCapturesErrorWhenMarkFailedThrows() {
+        LmsUserBatchProcessing staleBatch = buildStaleBatch(1L, UUID.randomUUID(), 42L);
+        String errorMessage = "update failed";
+
+        when(lmsUserBatchProcessingRepository.findAllByStatusAndUpdatedAtBefore(eq(LmsUserBatchStatus.IN_PROGRESS), any(Timestamp.class))).thenReturn(List.of(staleBatch));
+        doThrow(new RuntimeException(errorMessage)).when(lmsUserBatchWriteService).markFailed(any(UUID.class), anyString());
+
+        Optional<LmsUserBatchCleanerScheduleResult> result = lmsUserBatchCleanerSchedulerService.cleanup(STALE_TTL_MINUTES);
+
+        assertTrue(result.isPresent());
+        assertEquals(List.of(errorMessage), result.get().getProcessed().get(0).getErrors());
+    }
+
+    @Test
+    public void testCleanupProcessesMultipleStaleBatchesIndependently() {
+        LmsUserBatchProcessing succeeds = buildStaleBatch(1L, UUID.randomUUID(), 42L);
+        LmsUserBatchProcessing fails = buildStaleBatch(2L, UUID.randomUUID(), 43L);
+        String errorMessage = "update failed";
+
+        when(lmsUserBatchProcessingRepository.findAllByStatusAndUpdatedAtBefore(eq(LmsUserBatchStatus.IN_PROGRESS), any(Timestamp.class))).thenReturn(List.of(succeeds, fails));
+        doThrow(new RuntimeException(errorMessage)).when(lmsUserBatchWriteService).markFailed(eq(fails.getBatchId()), anyString());
+
+        Optional<LmsUserBatchCleanerScheduleResult> result = lmsUserBatchCleanerSchedulerService.cleanup(STALE_TTL_MINUTES);
+
+        assertTrue(result.isPresent());
+        assertEquals(2, result.get().getProcessed().size());
+
+        assertNull(result.get().getProcessed().get(0).getErrors());
+        assertEquals(List.of(errorMessage), result.get().getProcessed().get(1).getErrors());
+
+        verify(lmsUserBatchWriteService).markFailed(eq(succeeds.getBatchId()), anyString());
+        verify(lmsUserBatchWriteService).markFailed(eq(fails.getBatchId()), anyString());
+    }
+
+    private LmsUserBatchProcessing buildStaleBatch(long id, UUID batchId, long contextId) {
+        LmsUserBatchProcessing lmsUserBatchProcessing = LmsUserBatchProcessing.builder()
+            .id(id)
+            .batchId(batchId)
+            .contextId(contextId)
+            .status(LmsUserBatchStatus.IN_PROGRESS)
+            .build();
+
+        Timestamp staleTimestamp = Timestamp.from(Instant.now().minus(2, ChronoUnit.HOURS));
+        lmsUserBatchProcessing.setCreatedAt(staleTimestamp);
+        lmsUserBatchProcessing.setUpdatedAt(staleTimestamp);
+
+        return lmsUserBatchProcessing;
+    }
+
+}


### PR DESCRIPTION
@Async only means the sync runs on a background thread - it grants no crash-resilience. If that thread dies before reaching its own completion code (app restart/crash mid-sync, an uncaught Error, or the shared bounded task executor rejecting a new submission under load), the lms_user_batch_processing row is left IN_PROGRESS forever and its staged lms_user_batch rows are never cleaned up, with no existing job to catch it.

Adds LmsUserBatchCleanerSchedulerService/Runner, mirroring the existing ApiTokenCleanerScheduler pattern: finds rows IN_PROGRESS past a configurable staleness threshold (default 60 minutes), deletes their orphaned staging rows, and marks them FAILED via the existing LmsUserBatchWriteService.markFailed (already safe against racing writers).