### PR TITLE
Fix experiment data export still failing on Canvas "not authorized" f…

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImpl.java
@@ -69,6 +69,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -427,22 +428,20 @@ public class CanvasApiClientImpl implements ApiClient {
 
     @Override
     public List<LmsSubmission> listSubmissionsForMultipleAssignments(LtiUserEntity apiUser, String canvasCourseId, List<String> canvasAssignmentIds) throws ApiException, IOException, TerracottaConnectorException {
-        GetSubmissionsOptionsExtended submissionsOptions = new GetSubmissionsOptionsExtended(canvasCourseId, canvasAssignmentIds);
-        submissionsOptions.includes(Collections.singletonList(GetSubmissionsOptions.Include.USER));
-        // without student_ids[], Canvas defaults to the calling user's own submission - since the
-        // instructor calling this isn't a student in the course, Canvas rejects that as
-        // unauthorized rather than returning an empty list (see the single-assignment
-        // listSubmissions above, which already sets this)
-        submissionsOptions.userIds(List.of(GetSubmissionsOptionsExtended.UserId.ALL.toString()));
+        // Canvas's bulk "list submissions for multiple assignments" endpoint
+        // (GET .../students/submissions) requires a Canvas API scope that can't be granted
+        // retroactively on an already-configured Developer Key at any existing Canvas instance -
+        // each institution's admin would need to check that scope themselves - so it always
+        // 401s ("User is not authorized to perform this action") in practice. Fetch each
+        // assignment's submissions separately instead, via the single-assignment endpoint above,
+        // which is already granted and working.
+        List<LmsSubmission> submissions = new ArrayList<>();
 
-        try {
-            return castList(
-                getReader(apiUser, SubmissionReaderExtended.class)
-                    .listSubmissionsForMultipleAssignments(submissionsOptions)
-            );
-        } catch (Exception e) {
-            throw new ApiException(String.format("Failed to list submissions for the assignments with IDs: [%s] in the course with ID: [%s] in Canvas", String.join(",", canvasAssignmentIds), canvasCourseId), e);
+        for (String canvasAssignmentId : canvasAssignmentIds) {
+            submissions.addAll(listSubmissions(apiUser, canvasAssignmentId, canvasCourseId));
         }
+
+        return submissions;
     }
 
     @Override

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/SubmissionReaderExtended.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/SubmissionReaderExtended.java
@@ -2,7 +2,6 @@ package edu.iu.terracotta.connectors.canvas.service.extended;
 
 
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.SubmissionExtended;
-import edu.iu.terracotta.connectors.canvas.dao.model.extended.options.GetSubmissionsOptionsExtended;
 import edu.ksu.canvas.interfaces.CanvasReader;
 import edu.ksu.canvas.requestOptions.GetSubmissionsOptions;
 
@@ -11,7 +10,6 @@ import java.util.List;
 
 public interface SubmissionReaderExtended extends CanvasReader<SubmissionExtended, SubmissionReaderExtended> {
 
-    List<SubmissionExtended> listSubmissionsForMultipleAssignments(GetSubmissionsOptionsExtended options) throws IOException;
     List<SubmissionExtended> getCourseSubmissions(GetSubmissionsOptions options) throws IOException;
 
 }

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/SubmissionExtendedImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/SubmissionExtendedImpl.java
@@ -3,7 +3,6 @@ package edu.iu.terracotta.connectors.canvas.service.extended.impl;
 import com.google.gson.reflect.TypeToken;
 
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.SubmissionExtended;
-import edu.iu.terracotta.connectors.canvas.dao.model.extended.options.GetSubmissionsOptionsExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.SubmissionReaderExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.SubmissionWriterExtended;
 import edu.ksu.canvas.impl.BaseImpl;
@@ -25,11 +24,6 @@ public class SubmissionExtendedImpl extends BaseImpl<SubmissionExtended, Submiss
     public SubmissionExtendedImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
         super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize, serializeNulls);
         this.submissionImpl = new SubmissionImpl(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize, serializeNulls);
-    }
-
-    @Override
-    public List<SubmissionExtended> listSubmissionsForMultipleAssignments(GetSubmissionsOptionsExtended options) throws IOException {
-        return parseList(submissionImpl.listCourseSubmissionsForMultipleAssignments(options));
     }
 
     @Override

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/api/impl/CanvasApiClientImplTest.java
@@ -35,7 +35,6 @@ import edu.iu.terracotta.connectors.canvas.dao.model.extended.AssignmentExtended
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.ConversationExtended;
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.FileExtended;
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.FolderExtended;
-import edu.iu.terracotta.connectors.canvas.dao.model.extended.options.GetSubmissionsOptionsExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.AssignmentReaderExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.AssignmentWriterExtended;
 import edu.iu.terracotta.connectors.canvas.service.extended.ConversationReaderExtended;
@@ -727,10 +726,16 @@ public class CanvasApiClientImplTest extends BaseTest {
     }
 
     // listSubmissionsForMultipleAssignments
+    //
+    // Canvas's bulk "list submissions for multiple assignments" endpoint requires a Canvas API
+    // scope that can't be granted retroactively on an already-configured Developer Key at any
+    // existing Canvas instance, so it always 401s in practice ("User is not authorized to
+    // perform this action") - see the production incident this fixes. It's implemented as a
+    // loop over the already-working, already-granted single-assignment endpoint instead.
 
     @Test
     void testListSubmissionsForMultipleAssignmentsSuccess() throws Exception {
-        when(submissionReaderExtended.listSubmissionsForMultipleAssignments(any())).thenReturn(List.of(canvasSubmissionExtended));
+        when(submissionReaderExtended.getCourseSubmissions(any())).thenReturn(List.of(canvasSubmissionExtended));
         when(canvasSubmissionExtended.from()).thenReturn(lmsSubmission);
 
         List<LmsSubmission> result;
@@ -739,30 +744,13 @@ public class CanvasApiClientImplTest extends BaseTest {
             result = canvasApiClientService.listSubmissionsForMultipleAssignments(ltiUserEntity, "course1", List.of("1", "2"));
         }
 
-        assertEquals(1, result.size());
-    }
-
-    // without student_ids[]=all, Canvas defaults to the calling user's own submission and
-    // rejects the request as unauthorized for an instructor who isn't enrolled as a student -
-    // see the "User is not authorized to perform this action" production incident this fixes
-    @Test
-    void testListSubmissionsForMultipleAssignmentsRequestsAllStudentIds() throws Exception {
-        when(submissionReaderExtended.listSubmissionsForMultipleAssignments(any())).thenReturn(List.of(canvasSubmissionExtended));
-        when(canvasSubmissionExtended.from()).thenReturn(lmsSubmission);
-
-        ArgumentCaptor<GetSubmissionsOptionsExtended> optionsCaptor = ArgumentCaptor.forClass(GetSubmissionsOptionsExtended.class);
-
-        try (MockedConstruction<CanvasApiFactoryExtended> _ = mockApiFactory()) {
-            canvasApiClientService.listSubmissionsForMultipleAssignments(ltiUserEntity, "course1", List.of("1", "2"));
-        }
-
-        verify(submissionReaderExtended).listSubmissionsForMultipleAssignments(optionsCaptor.capture());
-        assertEquals(List.of("all"), optionsCaptor.getValue().getOptionsMap().get("student_ids[]"));
+        assertEquals(2, result.size());
+        verify(submissionReaderExtended, times(2)).getCourseSubmissions(any());
     }
 
     @Test
     void testListSubmissionsForMultipleAssignmentsWrapsException() throws Exception {
-        when(submissionReaderExtended.listSubmissionsForMultipleAssignments(any())).thenThrow(new IOException("fail"));
+        when(submissionReaderExtended.getCourseSubmissions(any())).thenThrow(new IOException("fail"));
 
         try (MockedConstruction<CanvasApiFactoryExtended> _ = mockApiFactory()) {
             assertThrows(ApiException.class, () -> canvasApiClientService.listSubmissionsForMultipleAssignments(ltiUserEntity, "course1", List.of("1", "2")));

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/SubmissionExtendedImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/extended/impl/SubmissionExtendedImplTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import edu.iu.terracotta.connectors.canvas.dao.model.extended.SubmissionExtended;
-import edu.iu.terracotta.connectors.canvas.dao.model.extended.options.GetSubmissionsOptionsExtended;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
@@ -34,52 +33,6 @@ public class SubmissionExtendedImplTest {
         MockitoAnnotations.openMocks(this);
 
         submissionExtended = new SubmissionExtendedImpl("https://canvas.example.com", 1, oauthToken, restClient, 1000, 1000, 100, false);
-    }
-
-    @Test
-    public void testListSubmissionsForMultipleAssignmentsReturnsParsedSubmissions() throws Exception {
-        Response response = new Response();
-        response.setErrorHappened(false);
-        response.setResponseCode(200);
-        response.setContent("[{\"id\":10,\"assignment_id\":100,\"user_id\":200,\"score\":95.5,\"workflow_state\":\"graded\"},"
-            + "{\"id\":11,\"assignment_id\":100,\"user_id\":201,\"score\":88.0,\"workflow_state\":\"submitted\"}]");
-        response.setNextLink(null);
-
-        when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
-
-        List<SubmissionExtended> results = submissionExtended.listSubmissionsForMultipleAssignments(
-            new GetSubmissionsOptionsExtended("1", List.of("100"))
-        );
-
-        assertEquals(2, results.size());
-        assertEquals("100", results.get(0).getAssignmentId());
-        assertEquals("200", results.get(0).getUserId());
-        assertEquals(95.5, results.get(0).getScore(), 0.0001);
-        assertEquals("graded", results.get(0).getState());
-        assertEquals("201", results.get(1).getUserId());
-        assertEquals("submitted", results.get(1).getState());
-    }
-
-    @Test
-    public void testListSubmissionsForMultipleAssignmentsThrowsExceptionWhenCanvasIdBlank() {
-        GetSubmissionsOptionsExtended options = new GetSubmissionsOptionsExtended("", List.of("100"));
-
-        assertThrows(IllegalArgumentException.class, () -> submissionExtended.listSubmissionsForMultipleAssignments(options));
-    }
-
-    @Test
-    public void testListSubmissionsForMultipleAssignmentsReturnsEmptyListWhenCanvasErrors() throws Exception {
-        Response response = new Response();
-        response.setErrorHappened(true);
-        response.setResponseCode(500);
-
-        when(restClient.sendApiGet(eq(oauthToken), anyString(), anyInt(), anyInt())).thenReturn(response);
-
-        List<SubmissionExtended> results = submissionExtended.listSubmissionsForMultipleAssignments(
-            new GetSubmissionsOptionsExtended("1", List.of("100"))
-        );
-
-        assertTrue(results.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
…or multi-assignment submissions

The previous fix (student_ids[]=all) was insufficient: Canvas's bulk "list submissions for multiple assignments" endpoint (GET .../students/submissions) requires a Canvas API scope that isn't - and can't retroactively be - granted on an already-configured Developer Key at any existing Canvas instance, since that requires each institution's own admin to check the scope themselves. Confirmed by running the full Liquibase migration chain against a real MySQL 8.4 instance while investigating an "add the missing scope" migration: even a correct migration can't grant a scope Canvas itself won't recognize as enabled for that key.

Instead, listSubmissionsForMultipleAssignments now loops over each assignment ID and calls the single-assignment listSubmissions (already scoped and working) rather than the bulk endpoint. Removed the now-dead SubmissionReaderExtended/SubmissionExtendedImpl bindings to that bulk endpoint so nothing can call it again by accident.