### PR TITLE
Correct blank-userKey guard scope and stop mismapping lmsUserId from …

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImpl.java
@@ -152,7 +152,10 @@ public class BrightspaceAdvantageMembershipServiceImpl implements AdvantageMembe
                 LmsUserBatch.builder()
                     .batchId(batchId)
                     .email(courseUser.getEmail())
-                    .lmsUserId(String.valueOf(courseUser.getUserId()))
+                    // NOT the LMS's own internal user ID - NRPS's user_id is the LTI-scoped
+                    // opaque identifier (already captured as userKey below). Getting the real
+                    // LMS user ID would require a resource-link-scoped request (rlid), which
+                    // doesn't apply to a course-wide roster sync.
                     .name(courseUser.getName())
                     .userKey(courseUser.getUserId())
                     .build()

--- a/src/main/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImpl.java
@@ -139,7 +139,10 @@ public class CanvasAdvantageMembershipServiceImpl implements AdvantageMembership
                 LmsUserBatch.builder()
                     .batchId(batchId)
                     .email(courseUser.getEmail())
-                    .lmsUserId(String.valueOf(courseUser.getUserId()))
+                    // NOT the LMS's own internal user ID - NRPS's user_id is the LTI-scoped
+                    // opaque identifier (already captured as userKey below). Getting the real
+                    // LMS user ID would require a resource-link-scoped request (rlid), which
+                    // doesn't apply to a course-wide roster sync.
                     .name(courseUser.getName())
                     .userKey(courseUser.getUserId())
                     .build()

--- a/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +15,9 @@ import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchProce
 import edu.iu.terracotta.connectors.generic.dao.repository.lms.LmsUserBatchRepository;
 import edu.iu.terracotta.connectors.generic.service.lms.LmsUserBatchWriteService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
-@SuppressWarnings({"PMD.GuardLogStatement"})
 public class LmsUserBatchWriteServiceImpl implements LmsUserBatchWriteService {
 
     private final LmsUserBatchProcessingRepository lmsUserBatchProcessingRepository;
@@ -49,30 +45,7 @@ public class LmsUserBatchWriteServiceImpl implements LmsUserBatchWriteService {
             return;
         }
 
-        // the LMS occasionally returns a roster entry with no usable user identifier (e.g. a
-        // pending/placeholder enrollment) - LtiUserEntity's constructor asserts on a blank
-        // userKey, and letting one through here would blow up the whole page's transaction
-        // (ParticipantRosterWriteServiceImpl.syncParticipantsPage), silently dropping every other
-        // participant in that page along with it
-        List<LmsUserBatch> validUsersToSave = usersToSave.stream()
-            .filter(
-                user -> {
-                    if (StringUtils.isNotBlank(user.getUserKey())) {
-                        return true;
-                    }
-
-                    log.warn("Skipping LMS user batch row with a blank user key; lmsUserId: [{}]", user.getLmsUserId());
-
-                    return false;
-                }
-            )
-            .toList();
-
-        if (CollectionUtils.isEmpty(validUsersToSave)) {
-            return;
-        }
-
-        lmsUserBatchRepository.saveAll(validUsersToSave);
+        lmsUserBatchRepository.saveAll(usersToSave);
     }
 
     @Override

--- a/src/main/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImpl.java
@@ -152,7 +152,10 @@ public class OneEdTechAdvantageMembershipServiceImpl implements AdvantageMembers
                 LmsUserBatch.builder()
                     .batchId(batchId)
                     .email(courseUser.getEmail())
-                    .lmsUserId(String.valueOf(courseUser.getUserId()))
+                    // NOT the LMS's own internal user ID - NRPS's user_id is the LTI-scoped
+                    // opaque identifier (already captured as userKey below). Getting the real
+                    // LMS user ID would require a resource-link-scoped request (rlid), which
+                    // doesn't apply to a course-wide roster sync.
                     .name(courseUser.getName())
                     .userKey(courseUser.getUserId())
                     .build()

--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantRosterWriteServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantRosterWriteServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -25,9 +26,12 @@ import edu.iu.terracotta.utils.ParticipantConsentUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings({"PMD.GuardLogStatement"})
 public class ParticipantRosterWriteServiceImpl implements ParticipantRosterWriteService {
 
     private final ParticipantRepository participantRepository;
@@ -38,6 +42,18 @@ public class ParticipantRosterWriteServiceImpl implements ParticipantRosterWrite
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void syncParticipantsPage(Experiment experiment, List<LmsUserBatch> batchUsers) {
+        // the LMS occasionally returns a roster entry with no usable user identifier (e.g. a
+        // pending/placeholder enrollment) - LtiUserEntity's constructor asserts on a blank
+        // userKey, and letting one through would blow up this whole page's transaction, silently
+        // dropping every other participant in the page along with it. One summary line rather
+        // than one per row, since a course missing this field tends to be missing it for every row.
+        long skipped = batchUsers.stream().filter(batchUser -> StringUtils.isBlank(batchUser.getUserKey())).count();
+
+        if (skipped > 0) {
+            log.warn("Skipped [{}] LMS user batch row(s) with a blank user key for experiment ID: [{}]", skipped, experiment.getExperimentId());
+            batchUsers = batchUsers.stream().filter(batchUser -> StringUtils.isNotBlank(batchUser.getUserKey())).toList();
+        }
+
         // retrieve batch of participants; reset dropped value and will set to false later, if found in the course roster
         List<Participant> participants = participantRepository.findAllByExperiment_ExperimentIdAndLtiUserEntity_UserKeyIn(
             experiment.getExperimentId(),

--- a/src/test/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/brightspace/service/lti/advantage/impl/BrightspaceAdvantageMembershipServiceImplTest.java
@@ -86,7 +86,9 @@ public class BrightspaceAdvantageMembershipServiceImplTest extends BaseTest {
         ArgumentCaptor<List<LmsUserBatch>> captor = ArgumentCaptor.forClass(List.class);
         verify(lmsUserBatchRepository).saveAll(captor.capture());
         assertEquals(1, captor.getValue().size());
-        assertEquals("user_id", captor.getValue().get(0).getLmsUserId());
+        // NRPS's user_id is the LTI-scoped opaque identifier, not the LMS's own internal user ID -
+        // must not be mistaken for one (see userKey, which correctly captures it)
+        assertNull(captor.getValue().get(0).getLmsUserId());
         assertEquals(batchId, captor.getValue().get(0).getBatchId());
     }
 

--- a/src/test/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/canvas/service/lti/advantage/impl/CanvasAdvantageMembershipServiceImplTest.java
@@ -79,7 +79,9 @@ public class CanvasAdvantageMembershipServiceImplTest extends BaseTest {
         ArgumentCaptor<List<LmsUserBatch>> captor = ArgumentCaptor.forClass(List.class);
         verify(lmsUserBatchWriteService).saveUsers(captor.capture());
         assertEquals(1, captor.getValue().size());
-        assertEquals("user_id", captor.getValue().get(0).getLmsUserId());
+        // NRPS's user_id is the LTI-scoped opaque identifier, not Canvas's own internal user ID -
+        // must not be mistaken for one (see userKey, which correctly captures it)
+        assertNull(captor.getValue().get(0).getLmsUserId());
         assertEquals(batchId, captor.getValue().get(0).getBatchId());
     }
 

--- a/src/test/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/generic/service/lms/impl/LmsUserBatchWriteServiceImplTest.java
@@ -70,7 +70,7 @@ public class LmsUserBatchWriteServiceImplTest {
 
     @Test
     public void testSaveUsersSavesAllWhenNonEmpty() {
-        List<LmsUserBatch> users = List.of(LmsUserBatch.builder().userKey("user-key").build());
+        List<LmsUserBatch> users = List.of(LmsUserBatch.builder().build());
 
         lmsUserBatchWriteService.saveUsers(users);
 
@@ -80,29 +80,6 @@ public class LmsUserBatchWriteServiceImplTest {
     @Test
     public void testSaveUsersSkipsRepositoryWhenEmpty() {
         lmsUserBatchWriteService.saveUsers(List.of());
-
-        verify(lmsUserBatchRepository, never()).saveAll(any());
-    }
-
-    // a roster entry with no usable identifier (e.g. a pending/placeholder LMS enrollment) must
-    // not reach LtiUserEntity's constructor, which asserts on a blank userKey and would take down
-    // the whole page's transaction - see ParticipantRosterWriteServiceImpl.syncParticipantsPage
-    @Test
-    public void testSaveUsersFiltersOutBlankUserKeys() {
-        LmsUserBatch valid = LmsUserBatch.builder().userKey("user-key").build();
-        LmsUserBatch blank = LmsUserBatch.builder().userKey("").lmsUserId("999").build();
-        LmsUserBatch nullKey = LmsUserBatch.builder().userKey(null).lmsUserId("1000").build();
-
-        lmsUserBatchWriteService.saveUsers(List.of(valid, blank, nullKey));
-
-        ArgumentCaptor<List<LmsUserBatch>> captor = ArgumentCaptor.forClass(List.class);
-        verify(lmsUserBatchRepository).saveAll(captor.capture());
-        assertEquals(List.of(valid), captor.getValue());
-    }
-
-    @Test
-    public void testSaveUsersSkipsRepositoryWhenAllUserKeysBlank() {
-        lmsUserBatchWriteService.saveUsers(List.of(LmsUserBatch.builder().userKey("").build()));
 
         verify(lmsUserBatchRepository, never()).saveAll(any());
     }

--- a/src/test/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/oneedtech/service/lti/advantage/impl/OneEdTechAdvantageMembershipServiceImplTest.java
@@ -145,7 +145,9 @@ public class OneEdTechAdvantageMembershipServiceImplTest extends BaseTest {
         ArgumentCaptor<List<LmsUserBatch>> captor = ArgumentCaptor.forClass(List.class);
         verify(lmsUserBatchRepository).saveAll(captor.capture());
         assertEquals(1, captor.getValue().size());
-        assertEquals("learnerId", captor.getValue().get(0).getLmsUserId());
+        // NRPS's user_id is the LTI-scoped opaque identifier, not the LMS's own internal user ID -
+        // must not be mistaken for one (see userKey, which correctly captures it)
+        assertNull(captor.getValue().get(0).getLmsUserId());
     }
 
     @Test

--- a/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantRosterWriteServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/impl/ParticipantRosterWriteServiceImplTest.java
@@ -134,6 +134,24 @@ public class ParticipantRosterWriteServiceImplTest extends BaseTest {
         assertEquals(ltiMembershipEntity, participantCaptor.getValue().getLtiMembershipEntity());
     }
 
+    // a roster entry with no usable user identifier (e.g. a pending/placeholder LMS enrollment)
+    // must be skipped rather than reaching LtiUserEntity's constructor, which asserts on a blank
+    // userKey and would take down this whole page's transaction along with every other
+    // participant in it.
+    @Test
+    public void testSyncParticipantsPageSkipsBlankUserKeysWithoutAffectingOthers() {
+        LmsUserBatch validBatchUser = LmsUserBatch.builder().userKey(USER_ID).email(EMAIL).name(DISPLAY_NAME).build();
+        LmsUserBatch blankBatchUser = LmsUserBatch.builder().userKey("").email("blank@example.com").name("Blank User").build();
+
+        when(participantRepository.findAllByExperiment_ExperimentIdAndLtiUserEntity_UserKeyIn(anyLong(), anyList())).thenReturn(List.of(participant));
+
+        assertDoesNotThrow(() -> participantRosterWriteService.syncParticipantsPage(experiment, List.of(validBatchUser, blankBatchUser)));
+
+        verify(participant).setDropped(false);
+        verify(participantRepository).save(participant);
+        verify(ltiDataService, never()).saveLtiUserEntity(any());
+    }
+
     // userKey matching (both against existing participants and the batched LtiUserEntity lookup)
     // must be case-insensitive, same as the single-user queries this replaced.
     @Test


### PR DESCRIPTION
…NRPS

The blank-userKey filter added in the previous commit lived in the shared LmsUserBatchWriteServiceImpl.saveUsers, which is used by two unrelated flows: the NRPS roster sync (needs userKey) and the REST-based Canvas-ID backfill (matches by email, never sets userKey by design). Filtering there discarded 100% of the backfill flow's rows on every run. Move the guard to ParticipantRosterWriteServiceImpl, the only consumer that actually needs userKey, and log one aggregated summary per page instead of one line per row.

Also fixes a real data bug found while investigating: all three LMS connectors' NRPS addToBatchData mapped both userKey and lmsUserId from the same courseUser.getUserId() value. That value is the LTI-scoped opaque user_id (Canvas's user.lti_id), not the LMS's own internal user ID - lmsUserId is compared against submission APIs' numeric user IDs elsewhere (OutcomeServiceImpl, MessageSendServiceImpl, etc.), so mapping it from the wrong source would silently break those comparisons for any NRPS-sourced row. Leave it unset for these rows instead of duplicating userKey into it.