### PR TITLE
Fix membership creation failing on concurrent launch/roster-sync race

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/generic/service/lti/impl/LtiDataServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/generic/service/lti/impl/LtiDataServiceImpl.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -449,7 +451,22 @@ public class LtiDataServiceImpl implements LtiDataService {
 
     @Override
     public LtiMembershipEntity saveLtiMembershipEntity(LtiMembershipEntity ltiMembershipEntity) {
-        return ltiMembershipRepository.save(ltiMembershipEntity);
+        try {
+            return ltiMembershipRepository.save(ltiMembershipEntity);
+        } catch (DataIntegrityViolationException | CannotAcquireLockException e) {
+            // a concurrent writer can race to create the same (user_id, context_id) membership -
+            // e.g. this same user's real LTI launch landing while a roster sync is independently
+            // creating their membership, or vice versa. Whichever commits first wins; the loser
+            // should use that row instead of failing whatever it was part of (a whole roster sync
+            // page, or the launch itself)
+            LtiMembershipEntity existing = ltiMembershipRepository.findByUserAndContext(ltiMembershipEntity.getUser(), ltiMembershipEntity.getContext());
+
+            if (existing != null) {
+                return existing;
+            }
+
+            throw e;
+        }
     }
 
     @Override

--- a/src/test/java/edu/iu/terracotta/connectors/generic/service/lti/impl/LtiDataServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/connectors/generic/service/lti/impl/LtiDataServiceImplTest.java
@@ -688,6 +688,50 @@ public class LtiDataServiceImplTest {
         assertEquals(toSave, result);
     }
 
+    // a real LTI launch and a roster sync can race to create the same (user_id, context_id)
+    // membership - whichever loses the unique-constraint race must use the winner's row rather
+    // than failing whatever it was part of.
+    @Test
+    public void testSaveLtiMembershipEntityReturnsExistingRowOnDuplicateKeyConflict() {
+        LtiUserEntity u = new LtiUserEntity("user1", new Date(), null);
+        LtiContextEntity c = new LtiContextEntity("ctx1", ToolDeployment.builder().build(), "title", "json");
+        LtiMembershipEntity toSave = new LtiMembershipEntity(c, u, 1);
+        LtiMembershipEntity winner = new LtiMembershipEntity(c, u, 1);
+        when(ltiMembershipRepository.save(toSave)).thenThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"));
+        when(ltiMembershipRepository.findByUserAndContext(u, c)).thenReturn(winner);
+
+        LtiMembershipEntity result = ltiDataService.saveLtiMembershipEntity(toSave);
+
+        assertEquals(winner, result);
+    }
+
+    @Test
+    public void testSaveLtiMembershipEntityReturnsExistingRowOnLockWaitTimeout() {
+        LtiUserEntity u = new LtiUserEntity("user1", new Date(), null);
+        LtiContextEntity c = new LtiContextEntity("ctx1", ToolDeployment.builder().build(), "title", "json");
+        LtiMembershipEntity toSave = new LtiMembershipEntity(c, u, 1);
+        LtiMembershipEntity winner = new LtiMembershipEntity(c, u, 1);
+        when(ltiMembershipRepository.save(toSave)).thenThrow(new org.springframework.dao.CannotAcquireLockException("lock wait timeout"));
+        when(ltiMembershipRepository.findByUserAndContext(u, c)).thenReturn(winner);
+
+        LtiMembershipEntity result = ltiDataService.saveLtiMembershipEntity(toSave);
+
+        assertEquals(winner, result);
+    }
+
+    // if the conflict wasn't actually caused by a concurrent winner (e.g. a genuinely different
+    // problem), rethrow rather than silently returning null and pushing an NPE onto the caller.
+    @Test
+    public void testSaveLtiMembershipEntityRethrowsWhenNoExistingRowFound() {
+        LtiUserEntity u = new LtiUserEntity("user1", new Date(), null);
+        LtiContextEntity c = new LtiContextEntity("ctx1", ToolDeployment.builder().build(), "title", "json");
+        LtiMembershipEntity toSave = new LtiMembershipEntity(c, u, 1);
+        when(ltiMembershipRepository.save(toSave)).thenThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"));
+        when(ltiMembershipRepository.findByUserAndContext(u, c)).thenReturn(null);
+
+        assertThrows(org.springframework.dao.DataIntegrityViolationException.class, () -> ltiDataService.saveLtiMembershipEntity(toSave));
+    }
+
     @Test
     public void testFindAllByUserKeysAndPlatformDeploymentDelegatesToRepository() {
         LtiUserEntity expected = new LtiUserEntity("user1", new Date(), null);


### PR DESCRIPTION
lti_membership has a unique constraint on (user_id, context_id). A real LTI launch and a roster sync can independently check "does this membership exist?", both see no, and both try to insert - the roster sync holds its REQUIRES_NEW transaction open across an entire page of users, so the loser can block long enough to hit MySQL's lock-wait timeout, failing the whole page (or the launch) it was part of.

Catch the conflict in saveLtiMembershipEntity, the one place both paths funnel through, and fall back to the winner's row instead of failing. Deliberately not extending the roster sync's per-context lock to the launch path - that would add lock/latency risk to every student's launch to guard against a rare race.