### PR TITLE
Fix ListParticipants showing nothing despite a real roster sync

### DIFF
--- a/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/ParticipantServiceImpl.java
@@ -152,8 +152,21 @@ public class ParticipantServiceImpl implements ParticipantService {
         return participantRepository.findByExperiment_ExperimentId(experimentId);
     }
 
+    // READ_COMMITTED (rather than MySQL's default REPEATABLE READ): this call chain may lead
+    // into refreshParticipants, which writes lms_user_batch via LmsUserBatchWriteService in a
+    // REQUIRES_NEW sub-transaction so a huge sync doesn't hold one giant lock for its whole
+    // duration. Under REPEATABLE READ, THIS transaction's consistent-read snapshot is fixed as of
+    // its first read (here, the very first repository call below) - so a REQUIRES_NEW
+    // sub-transaction that commits AFTER that point is invisible to this transaction's later
+    // reads, even though the rows are genuinely there (findByBatchId would return nothing for a
+    // batchId that demonstrably matches in the DB). READ_COMMITTED gives each statement in this
+    // transaction a fresh view of whatever's committed at that moment instead of a frozen one.
+    // Self-invocation within this class means only the actual entry point's isolation setting
+    // takes effect for a whole call chain, so this same isolation is set on every public method
+    // here that can be an entry point into refreshParticipants (see also refreshParticipants,
+    // refreshParticipantsIfStale, ensureParticipantExists, prepareParticipation below).
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public List<ParticipantDto> getParticipants(long experimentId, String userId, boolean student, SecuredInfo securedInfo, boolean refresh) throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         Experiment experiment = experimentRepository.findByExperimentId(experimentId);
         // retrieve published assignment IDs from LMS
@@ -322,8 +335,12 @@ public class ParticipantServiceImpl implements ParticipantService {
         participantRepository.saveAndFlush(participantToChange);
     }
 
+    // see the READ_COMMITTED comment on getParticipants above - only relevant if this method is
+    // ever an actual entry point (all current callers reach it via self-invocation from within
+    // this same class, where this annotation is bypassed and the real entry point's isolation
+    // governs instead)
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void refreshParticipants(long experimentId) throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         refreshParticipants(experimentId, UUID.randomUUID());
     }
@@ -382,8 +399,11 @@ public class ParticipantServiceImpl implements ParticipantService {
      *
      * @param experimentId
      */
+    // see the READ_COMMITTED comment on getParticipants above - this is a real entry point
+    // (OutcomeServiceImpl/ExportServiceImpl call it directly, and prepareParticipation below
+    // reaches it via self-invocation)
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void refreshParticipantsIfStale(long experimentId) throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         refreshParticipantsIfStale(experimentId, UUID.randomUUID());
     }
@@ -571,8 +591,11 @@ public class ParticipantServiceImpl implements ParticipantService {
         return participantRepository.save(newParticipant);
     }
 
+    // see the READ_COMMITTED comment on getParticipants above - a real entry point
+    // (StepsController calls it directly), and its fallback path reaches refreshParticipants via
+    // self-invocation
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void ensureParticipantExists(long experimentId, SecuredInfo securedInfo) throws ExperimentNotMatchingException, ParticipantNotUpdatedException, TerracottaConnectorException {
         Participant participant = participantRepository.findByExperiment_ExperimentIdAndLtiUserEntity_UserKey(experimentId, securedInfo.getUserId());
 
@@ -597,8 +620,11 @@ public class ParticipantServiceImpl implements ParticipantService {
         refreshParticipants(experimentId);
     }
 
+    // see the READ_COMMITTED comment on getParticipants above - a real entry point
+    // (ParticipantAsyncServiceImpl calls it directly), reaching refreshParticipantsIfStale
+    // (and from there refreshParticipants) via self-invocation
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void prepareParticipation(Long experimentId, SecuredInfo securedInfo, UUID batchId) throws ParticipantNotUpdatedException, ExperimentNotMatchingException, TerracottaConnectorException {
         // throttled, so picking/re-picking a participation type doesn't always force a full LMS
         // roster sync; still proactively populates the roster (rather than waiting for each


### PR DESCRIPTION
getParticipants (called directly by ParticipantController) ran under MySQL's default REPEATABLE READ. Its consistent-read snapshot is fixed at its first read - before refreshParticipantsIfStale's roster sync runs and commits new Participant rows via a REQUIRES_NEW sub-transaction. The method's own later read of the participant list, still using that frozen snapshot, missed everything the sync had just written, returning an empty list even though the rows were genuinely in the DB.

feature/TCOTA-992 already carries this fix (READ_COMMITTED on every public method that can be a real entry point into refreshParticipants: getParticipants, refreshParticipants, refreshParticipantsIfStale, ensureParticipantExists, prepareParticipation, startPrepareParticipation) - this branch only had it on startPrepareParticipation. Bring the other five up to parity; no 992 changes needed.