### PR TITLE
Fix recipient rule sets and conditional text always disabled

### DIFF
--- a/src/main/javascript/src/services/messaging/message.service.js
+++ b/src/main/javascript/src/services/messaging/message.service.js
@@ -56,13 +56,13 @@ async function sendTest(experimentId, exposureId, containerId, messageId, messag
 /**
  * Get all assignments for messaging rules
  */
-async function getAssignments() {
+async function getAssignments(experimentId, exposureId, containerId) {
   const requestOptions = {
     method: "GET",
     headers: { ...authHeader() }
   }
 
-  return fetch(`${store.getters["api/aud"]}/api/experiments/0/exposures/0/messaging/container/0/message/assignments`, requestOptions).then(handleResponse);
+  return fetch(`${store.getters["api/aud"]}/api/experiments/${experimentId}/exposures/${exposureId}/messaging/container/${containerId}/message/assignments`, requestOptions).then(handleResponse);
 }
 
 /**

--- a/src/main/javascript/src/store/messaging/message.module.js
+++ b/src/main/javascript/src/store/messaging/message.module.js
@@ -34,10 +34,11 @@ const actions = {
       console.error("sendTest catch", {e});
     }
   },
-  async getAssignments({ commit }) {
+  async getAssignments({ commit }, payload) {
+    // payload: experimentId, exposureId, containerId
     try {
       commit("setIsLoading", true);
-      const response = await messageService.getAssignments();
+      const response = await messageService.getAssignments(...payload);
       commit("setAssignments", response);
     } catch (e) {
       console.error("update catch", {e});

--- a/src/main/javascript/src/views/messaging/Message.vue
+++ b/src/main/javascript/src/views/messaging/Message.vue
@@ -1130,7 +1130,11 @@ export default {
       });
     },
     async initialize() {
-      this.fetchMessageRuleAssignments();
+      this.fetchMessageRuleAssignments([
+        this.experimentId,
+        this.exposureId,
+        this.containerId
+      ]);
       this.resetConditionalTexts();
       this.initialContent = this.html;
       this.setMessageConditionalTexts(this.content.conditionalTexts);


### PR DESCRIPTION
messageService.getAssignments() hardcoded experimentId/exposureId/ containerId as literal "0" in its request URL, regardless of the actual message being edited. The backend route requires a real UUID for containerId, so the request 400s, the frontend's catch falls back to an empty/error response, and messagingMessage.assignments is always empty - which permanently disables Recipients' rule-set UI and the "insert conditional text" buttons via hasMessageRuleAssignments, independent of whether the message has been sent.

Thread the real experimentId/exposureId/containerId through from Message.vue's initialize() call.