### PR TITLE
Fix container status stuck at PUBLISHED after all messages send

### DIFF
--- a/src/main/java/edu/iu/terracotta/runner/messaging/impl/MessagingSchedulerServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/runner/messaging/impl/MessagingSchedulerServiceImpl.java
@@ -172,8 +172,10 @@ public class MessagingSchedulerServiceImpl implements MessagingSchedulerService 
     private void processContainerStatuses(Set<MessageContainer> messageContainers) {
         messageContainers.forEach(
             messageContainer -> {
+                // a DISABLED message ("include a message for this treatment" turned off) will
+                // never be sent; it shouldn't block the container from being marked SENT
                 boolean isAllSent = messageContainer.getMessages().stream()
-                    .allMatch(message -> message.getStatus() == MessageStatus.SENT);
+                    .allMatch(message -> message.getStatus() == MessageStatus.SENT || message.getStatus() == MessageStatus.DISABLED);
 
                 if (isAllSent) {
                     // all messages sent successfully; update group to SENT status

--- a/src/test/java/edu/iu/terracotta/runner/messaging/impl/MessagingSchedulerServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/runner/messaging/impl/MessagingSchedulerServiceImplTest.java
@@ -363,4 +363,25 @@ public class MessagingSchedulerServiceImplTest extends BaseTest {
         verify(messageContainerRepository, never()).save(any());
     }
 
+    @Test
+    public void testProcessContainerStatusesDisabledSiblingDoesNotBlockSentStatus() {
+        // a DISABLED sibling ("include a message for this treatment" turned off) never gets
+        // sent and never returned by the repository query; it must not block the container
+        // from being marked SENT once every other message in it has actually sent
+        MessageContainer container = buildContainer(MessageStatus.PUBLISHED);
+        Message sentMessage = buildMessage(container, MessageStatus.READY, MessageType.CONVERSATION, Timestamp.from(Instant.now().minusSeconds(600)), 0, KEY_ID);
+        buildMessage(container, MessageStatus.DISABLED, MessageType.CONVERSATION, Timestamp.from(Instant.now().minusSeconds(600)), 0, KEY_ID);
+
+        when(messageRepository.findAllByContainer_Configuration_StatusAndConfiguration_Status(MessageStatus.PUBLISHED, MessageStatus.READY))
+            .thenReturn(List.of(sentMessage));
+        when(featureService.isFeatureEnabled(FeatureType.MESSAGING, KEY_ID)).thenReturn(true);
+
+        Optional<MessagingScheduleResult> result = messagingSchedulerService.send();
+
+        assertTrue(result.isPresent());
+        assertEquals(MessageStatus.SENT, sentMessage.getConfiguration().getStatus());
+        assertEquals(MessageStatus.SENT, container.getConfiguration().getStatus());
+        verify(messageContainerRepository, times(1)).save(container);
+    }
+
 }


### PR DESCRIPTION
processContainerStatuses()'s isAllSent check only accepted SENT, so a container with a DISABLED sibling message ("include a message for this treatment" turned off) could never satisfy it - a disabled message is never sent and never returned by the scheduler's query, so its status stays DISABLED forever, and isAnyError doesn't match it either. The container was left stuck at PUBLISHED indefinitely even after every other message in it sent successfully.

MessageContainerConfigurationServiceImpl.calculateStatus() already treats READY/SENT/DISABLED as the equivalent "resolved" set when deciding container readiness (line 190); apply the same treatment here for completion.