### PR TITLE
Fix "Error 108" losing questions after saving assessment settings

### DIFF
--- a/src/main/java/edu/iu/terracotta/service/app/impl/AssessmentServiceImpl.java
+++ b/src/main/java/edu/iu/terracotta/service/app/impl/AssessmentServiceImpl.java
@@ -429,6 +429,14 @@ public class AssessmentServiceImpl implements AssessmentService {
     }
 
     private void processAssessmentQuestions(Assessment assessment, AssessmentDto assessmentDto) throws IdInPostException, DataServiceException, QuestionNotMatchingException, NegativePointsException, MultipleChoiceLimitReachedException, IntegrationClientNotFoundException, IntegrationNotFoundException {
+        if (assessmentDto.getQuestions() == null) {
+            // no questions field in the request at all (e.g. TerracottaBuilder.vue's plain
+            // "save assessment settings" PUT, which never includes one) - leave existing
+            // questions untouched. Only an explicit empty list (the dedicated "clear questions"
+            // DELETE endpoint takes that path instead, not this one) should wipe them below.
+            return;
+        }
+
         if (CollectionUtils.isNotEmpty(assessmentDto.getQuestions())) {
             List<Long> existingQuestionIds = CollectionUtils.emptyIfNull(questionRepository.findByAssessment_AssessmentIdOrderByQuestionOrder(assessmentDto.getAssessmentId())).stream()
                 .map(Question::getQuestionId)

--- a/src/test/java/edu/iu/terracotta/service/app/impl/AssessmentServiceImplTest.java
+++ b/src/test/java/edu/iu/terracotta/service/app/impl/AssessmentServiceImplTest.java
@@ -402,6 +402,27 @@ public class AssessmentServiceImplTest extends BaseTest {
         verify(questionRepository, never()).deleteById(anyLong());
     }
 
+    // TerracottaBuilder.vue's plain "save assessment settings" PUT never includes a questions
+    // field, so assessmentDto.getQuestions() comes back null here (not an empty list) - that
+    // must leave existing questions untouched rather than deleting them all, otherwise the
+    // very next "save questions" request in the same save-all flow fails with
+    // QuestionNotMatchingException (Error 108) against the questions this just deleted.
+    @Test
+    public void testUpdateAssessmentWithNoQuestionsFieldLeavesExistingQuestionsUntouched()
+        throws TitleValidationException, RevealResponsesSettingValidationException, MultipleAttemptsSettingsValidationException,
+        AssessmentNotMatchingException, IdInPostException, DataServiceException, NegativePointsException, QuestionNotMatchingException, MultipleChoiceLimitReachedException,
+        IntegrationNotFoundException, IntegrationNotMatchingException, IntegrationConfigurationNotFoundException, IntegrationConfigurationNotMatchingException, IntegrationClientNotFoundException {
+        when(assessmentDto.getQuestions()).thenReturn(null);
+
+        assessmentService.updateAssessment(1L, assessmentDto, true);
+
+        verify(questionService, never()).postQuestion(any(QuestionDto.class), anyLong(), anyBoolean(), anyBoolean());
+        verify(questionRepository, never()).findByQuestionId(anyLong());
+        verify(questionService, never()).updateQuestion(anyMap());
+        verify(questionRepository, never()).deleteByQuestionId(anyLong());
+        verify(assessment, never()).getQuestions();
+    }
+
     @Test
     public void testVerifyNumSubmissionsLimitNullExistingAttemptNotExists() {
         assertDoesNotThrow(() -> verifySubmissionLimit.invoke(assessmentService, null, 0));


### PR DESCRIPTION
TerracottaBuilder.vue's saveAll() first PUTs assessment settings (no questions field at all) then PUTs the questions list. The settings-only PUT was hitting processAssessmentQuestions' "no questions passed" branch, which treats a missing questions field the same as an explicit empty list and deletes every question on the assessment. The very next request in the same save flow then tries to update those now-deleted questions and fails with QuestionNotMatchingException (Error 108), so nothing ends up saved.

Distinguish "field omitted" (leave questions alone) from "field explicitly empty" (the dedicated clear-questions DELETE endpoint's case) so a plain settings save no longer touches questions at all.