### PR TITLE
NO_JIRA - fix Brightspace JSON binding error in restoreAssignment/uploadConsentFile

### DIFF
--- a/src/main/java/edu/iu/terracotta/connectors/brightspace/service/api/impl/BrightspaceApiClientImpl.java
+++ b/src/main/java/edu/iu/terracotta/connectors/brightspace/service/api/impl/BrightspaceApiClientImpl.java
@@ -358,7 +358,10 @@ public class BrightspaceApiClientImpl implements ApiClient {
                 createLineItem(assignmentExtended, assignment, orgUnitId);
             }
 
-            return getWriter(assignment.getExposure().getExperiment().getCreatedBy(), AssignmentWriterService.class)
+            // see createLmsAssignment: serialize explicit nulls, or Brightspace's JSON binder
+            // rejects content-module creation outright when this restore path needs to
+            // (re)create one
+            return getWriter(assignment.getExposure().getExperiment().getCreatedBy(), AssignmentWriterService.class, true)
                 .createAssignment(orgUnitId, assignmentExtended.getAssignment())
                 .orElseThrow(() -> new ApiException(String.format("Failed to create Assignment in Brightspace course by orgUnitId [%s]", orgUnitId)));
         } catch (Exception e) {
@@ -644,7 +647,9 @@ public class BrightspaceApiClientImpl implements ApiClient {
 
             createLineItem(assignmentExtended, experiment, consentDocument, orgUnitId);
 
-            return getWriter(instructorUser, AssignmentWriterService.class)
+            // see createLmsAssignment: serialize explicit nulls, or Brightspace's JSON binder
+            // rejects content-module creation outright
+            return getWriter(instructorUser, AssignmentWriterService.class, true)
                 .createAssignment(orgUnitId, assignmentExtended.getAssignment())
                 .orElseThrow(() -> new ApiException(String.format("Failed to create Consent Assignment in Brightspace course by orgUnitId [%s]", orgUnitId)));
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Follow-up to #726: the same Brightspace "JSON Binding Error" fix (serialize explicit nulls so the content-module creation request matches Brightspace's expected shape) was only applied to `createLmsAssignment`. `restoreAssignment` and `uploadConsentFile` call the same underlying `AssignmentWriterService.createAssignment()` -> content module creation path, but were still using a writer that omits null fields by default, leaving them exposed to the same error.

## Test plan
- [x] Full backend test suite passes (4043 tests, 0 failures) with `-Dskip.yarn`
- [x] `BrightspaceApiClientImplTest` passes (64 tests), including `restoreAssignment`/`uploadConsentFile` cases