### PR TITLE
NO_JIRA - fix submissions.find is not a function crash

### DIFF
--- a/src/main/javascript/src/store/submission.module.js
+++ b/src/main/javascript/src/store/submission.module.js
@@ -21,9 +21,24 @@ export const submission = defineStore("submission", {
       try {
         const { data } = await submissionService.getAll(...payload);
 
-        this.submissions = data || [];
+        // a failed HTTP response resolves to an error object (e.g. {status, error}) rather than
+        // throwing, so an array check is needed here to catch that case as a failure too - without
+        // it, this.submissions ends up non-array and callers doing this.submissions.find(...)/
+        // .map(...) throw "submissions.find is not a function"
+        if (!Array.isArray(data)) {
+          console.error(
+            "submissions/fetchSubmissions | non-array response",
+            { data }
+          );
 
-        return data || [];
+          this.submissions = [];
+
+          return [];
+        }
+
+        this.submissions = data;
+
+        return data;
       } catch (error) {
         console.error(
           "submissions/fetchSubmissions | catch",
@@ -107,9 +122,22 @@ export const submission = defineStore("submission", {
         const { data } =
           await submissionService.getQuestionSubmissions(...payload);
 
-        this.questionSubmissions = data || [];
+        // see fetchSubmissions: a failed HTTP response resolves to a non-array error object
+        // rather than throwing, so it must be caught here too
+        if (!Array.isArray(data)) {
+          console.error(
+            "submissions/fetchQuestionSubmissions | non-array response",
+            { data }
+          );
 
-        return data || [];
+          this.questionSubmissions = [];
+
+          return [];
+        }
+
+        this.questionSubmissions = data;
+
+        return data;
       } catch (error) {
         console.error(
           "submissions/fetchQuestionSubmissions | catch",

--- a/src/main/javascript/src/store/submission.module.spec.js
+++ b/src/main/javascript/src/store/submission.module.spec.js
@@ -58,6 +58,18 @@ describe("submission store", () => {
       expect(store.submissions).toEqual([]);
     });
 
+    it("falls back to [] when the service resolves a non-array error object instead of throwing", async () => {
+      // a failed HTTP response (e.g. 401/403/500) resolves to {status, error} rather than
+      // rejecting - this must be treated as a fetch failure too, or callers doing
+      // store.submissions.find(...)/.map(...) would throw "submissions.find is not a function"
+      submissionService.getAll.mockResolvedValue({ data: { status: 403, error: "Forbidden" } });
+
+      const result = await store.fetchSubmissions(["a"]);
+
+      expect(result).toEqual([]);
+      expect(store.submissions).toEqual([]);
+    });
+
     it("returns [] on error", async () => {
       submissionService.getAll.mockRejectedValue(new Error("fail"));
 
@@ -155,6 +167,17 @@ describe("submission store", () => {
 
     it("falls back to [] when data missing", async () => {
       submissionService.getQuestionSubmissions.mockResolvedValue({});
+
+      const result = await store.fetchQuestionSubmissions(["a"]);
+
+      expect(result).toEqual([]);
+      expect(store.questionSubmissions).toEqual([]);
+    });
+
+    it("falls back to [] when the service resolves a non-array error object instead of throwing", async () => {
+      submissionService.getQuestionSubmissions.mockResolvedValue({
+        data: { status: 403, error: "Forbidden" }
+      });
 
       const result = await store.fetchQuestionSubmissions(["a"]);
 

--- a/src/main/javascript/src/views/student/quiz/StudentQuiz.spec.js
+++ b/src/main/javascript/src/views/student/quiz/StudentQuiz.spec.js
@@ -316,6 +316,60 @@ describe("StudentQuiz", () => {
     expect(wrapper.text()).toContain("Your answers have been submitted.");
   });
 
+  it("does not crash on submit when launch_assignment omits questionSubmissionDtoList (a fresh attempt)", async () => {
+    // regression test: launch_assignment previously assigned this field to submissions.value
+    // unchecked, so a null/missing value (as a fresh attempt with no prior question submissions
+    // can return) made the later saveAnswers()'s submissions.value.find(...) throw
+    // "submissions.value.find is not a function"
+    mockReportStepByStep({
+      launch_assignment: {
+        status: 200,
+        data: {
+          experimentId: "1",
+          conditionId: 101,
+          treatmentId: 102,
+          assessmentId: 103,
+          submissionId: 104,
+          questionSubmissionDtoList: null
+        }
+      }
+    });
+    submissionService.createQuestionSubmissions.mockResolvedValue({ status: 201, data: {} });
+
+    const wrapper = mountComponent(StudentQuiz, {
+      props: { experimentId: "1" },
+      global: { stubs: stubbedChildren }
+    });
+
+    await flushPromises();
+    await flushPromises();
+
+    const questionCard = wrapper.findComponent({ name: "StudentQuizQuestionCard" });
+    await questionCard.vm.$emit("update:question-values", [
+      { questionId: 10, answerId: 100, response: null }
+    ]);
+    await flushPromises();
+
+    await wrapper.find("form").trigger("submit");
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(submissionService.createQuestionSubmissions).toHaveBeenCalledWith(
+      "1", 101, 102, 103, 104,
+      [
+        expect.objectContaining({
+          questionId: 10,
+          answerSubmissionDtoList: [
+            expect.objectContaining({ answerId: 100, response: null })
+          ]
+        })
+      ]
+    );
+
+    expect(wrapper.text()).toContain("Your answers have been submitted.");
+  });
+
   it("delegates file downloads from the question card to the submission store and clears the in-flight id", async () => {
     mockReportStepByStep();
     let resolveDownload;

--- a/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
+++ b/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
@@ -430,7 +430,10 @@ const attempt = async (preferLmsChecks = false) => {
       treatmentId.value = data.treatmentId;
       assessmentId.value = data.assessmentId;
       submissionId.value = data.submissionId;
-      submissions.value = data.questionSubmissionDtoList;
+      // a fresh attempt with no prior question submissions can come back with this field
+      // missing/null rather than []; without the array check, saveAnswers' submissions.value.find(...)
+      // throws "submissions.value.find is not a function"
+      submissions.value = Array.isArray(data.questionSubmissionDtoList) ? data.questionSubmissionDtoList : [];
       // must resolve before checking isIntegration: it reads assessmentStore.assessment,
       // which this call is what populates in the first place
       await getQuestions(data.experimentId, data.conditionId, data.assessmentId, data.treatmentId, data.submissionId);


### PR DESCRIPTION
## Summary
- A failed HTTP response (401/403/500/etc.) resolves to an error object like `{status, error}` rather than throwing. `fetchSubmissions`/`fetchQuestionSubmissions` in the submission store were committing that directly to state with no array check, so a component calling `.find()`/`.map()` on it would throw `"submissions.find is not a function"`. Guard with `Array.isArray`, mirroring the same fix already applied to the participants store.
- `StudentQuiz.vue`'s `attempt()` had a second, more direct path: it assigned `submissions.value` straight from the `launch_assignment` response's `questionSubmissionDtoList` with no check at all. A fresh attempt with no prior question submissions can come back with that field `null` rather than `[]`, which crashed `submitQuiz`'s `saveAnswers()` on `submissions.value.find(...)`.

## Test plan
- [x] `submission.module.spec.js` and `StudentQuiz.spec.js` pass (41 tests), including new regression tests for both non-array-response cases
- [x] Full frontend suite passes (1534 tests, 175 files)
- [x] `eslint` clean on all changed files