### PR TITLE
NO_JIRA - fix exposures.find/map/filter is not a function crash

### DIFF
--- a/src/main/javascript/src/store/exposures.module.js
+++ b/src/main/javascript/src/store/exposures.module.js
@@ -16,7 +16,22 @@ export const exposures = defineStore("exposures", {
       try {
         const data = await exposuresService.getAll(experimentId);
 
-        this.exposures = data || [];
+        // a failed HTTP response resolves to an error object (e.g. {status, error}) rather than
+        // throwing, so an array check is needed here to catch that case as a failure too - without
+        // it, this.exposures ends up non-array and callers doing exposures.value.find(...)/
+        // .map(...)/.filter(...) throw "exposures.value.find is not a function"
+        if (!Array.isArray(data)) {
+          console.error(
+            "exposures/fetchExposures | non-array response",
+            { data }
+          );
+
+          this.exposures = [];
+
+          return [];
+        }
+
+        this.exposures = data;
 
         return this.exposures;
       } catch (error) {

--- a/src/main/javascript/src/store/exposures.module.spec.js
+++ b/src/main/javascript/src/store/exposures.module.spec.js
@@ -47,6 +47,19 @@ describe("exposures store", () => {
       expect(result).toEqual([]);
     });
 
+    it("resets exposures to [] when the service resolves a non-array error object instead of throwing", async () => {
+      // a failed HTTP response (e.g. 401/403/500) resolves to an object like {status, error}
+      // rather than rejecting - this must be treated as a fetch failure too, or components
+      // calling exposures.value.find()/.map()/.filter() would throw
+      store.exposures = [{ exposureId: 1 }];
+      exposuresService.getAll.mockResolvedValue({ status: 403, error: "Forbidden" });
+
+      const result = await store.fetchExposures(10);
+
+      expect(store.exposures).toEqual([]);
+      expect(result).toEqual([]);
+    });
+
     it("resets exposures to [] and logs on error", async () => {
       store.exposures = [{ exposureId: 1 }];
       exposuresService.getAll.mockRejectedValue(new Error("boom"));


### PR DESCRIPTION
## Summary
- Same bug class as #729 (submissions), on a different store. `exposuresService.getAll` is a "raw" service: it returns the array directly on success, but a failed HTTP response (401/403/500/etc.) resolves to an error object like `{status, error}` rather than throwing. `fetchExposures` was committing that directly to `state.exposures` with no array check, so a component calling `.find()`/`.map()`/`.filter()` on it would throw `"exposures.find is not a function"`.
- Guard with `Array.isArray`, mirroring the same fix already applied to the participants store (and already present in `groups.module.js`/`condition.module.js`).
- `exposures.value` is consumed with array methods in at least 8 places (`ExperimentAssignments.vue`, `TerracottaBuilder.vue`, `OutcomeScoring.vue`, `YourAssignments.vue`, `ExperimentSummaryStatus.vue`, `ParticipationManualDistribution.vue`, `DataTableTreatment.vue`), any of which would have thrown.

## Test plan
- [x] `exposures.module.spec.js` passes (8 tests), including a new regression test for the non-array-response case
- [x] Full frontend suite passes (1532 tests, 175 files)
- [x] `eslint` clean on all changed files