### PR TITLE
NO_JIRA - fix stuck-expired session token after a backgrounded browser tab

### DIFF
--- a/src/main/javascript/src/App.spec.js
+++ b/src/main/javascript/src/App.spec.js
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { flushPromises } from "@vue/test-utils";
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ meta: {} })
+}));
+
+vi.mock("sweetalert2", () => ({
+  default: {
+    fire: vi.fn().mockResolvedValue({})
+  }
+}));
+
+vi.mock("@/services", () => ({
+  apiService: {
+    getApiToken: vi.fn(),
+    refreshToken: vi.fn(),
+    reportStep: vi.fn(),
+    deepLinkJwt: vi.fn()
+  },
+  configurationService: {
+    get: vi.fn().mockResolvedValue({ data: {} })
+  }
+}));
+
+import Swal from "sweetalert2";
+import { apiService } from "@/services";
+import { mountComponent } from "@/test-utils/mount";
+import { api as apiModule } from "@/store/api.module";
+import App from "./App.vue";
+
+const FIFTY_NINE_MINUTES_MS = 1000 * 60 * 59;
+
+function base64url(obj) {
+  return Buffer.from(JSON.stringify(obj))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeToken(payload) {
+  return `${base64url({ alg: "HS256", typ: "JWT" })}.${base64url(payload)}.signature`;
+}
+
+function validToken() {
+  return makeToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+}
+
+function expiredToken() {
+  return makeToken({ exp: Math.floor(Date.now() / 1000) - 3600 });
+}
+
+async function mountApp(props = {}) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const apiStore = apiModule();
+
+  const wrapper = mountComponent(App, {
+    shallow: true,
+    pinia,
+    props
+  });
+
+  await flushPromises(); // let onMounted's await retrieveConfiguration() resolve
+
+  return { wrapper, apiStore };
+}
+
+function foregroundTab() {
+  Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("App", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("registers a refresh interval and a visibilitychange listener on mount, and tears both down on unmount", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+    const addListenerSpy = vi.spyOn(document, "addEventListener");
+    const removeListenerSpy = vi.spyOn(document, "removeEventListener");
+
+    const { wrapper } = await mountApp();
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), FIFTY_NINE_MINUTES_MS);
+    expect(addListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    wrapper.unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+  });
+
+  it("refreshes the token when the tab is foregrounded with a still-valid token", async () => {
+    const token = validToken();
+    apiService.refreshToken.mockResolvedValue(token);
+    const { apiStore } = await mountApp();
+    apiStore.apiToken = token;
+
+    foregroundTab();
+    await flushPromises();
+
+    expect(apiService.refreshToken).toHaveBeenCalled();
+    expect(Swal.fire).not.toHaveBeenCalled();
+  });
+
+  it("shows the session-expired dialog exactly once and stops monitoring when the tab is foregrounded with an already-expired token", async () => {
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+    const removeListenerSpy = vi.spyOn(document, "removeEventListener");
+    const { apiStore } = await mountApp();
+    apiStore.apiToken = expiredToken();
+
+    foregroundTab();
+    await flushPromises();
+
+    expect(apiService.refreshToken).not.toHaveBeenCalled();
+    expect(apiStore.sessionExpired).toBe(true);
+    expect(Swal.fire).toHaveBeenCalledTimes(1);
+    expect(Swal.fire).toHaveBeenCalledWith(expect.stringContaining("return to your course"));
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    foregroundTab();
+    await flushPromises();
+
+    expect(Swal.fire).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when there is no apiToken yet", async () => {
+    await mountApp();
+
+    foregroundTab();
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(FIFTY_NINE_MINUTES_MS);
+
+    expect(apiService.refreshToken).not.toHaveBeenCalled();
+    expect(Swal.fire).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on the 59-minute interval alone, without a visibility event", async () => {
+    const token = validToken();
+    apiService.refreshToken.mockResolvedValue(token);
+    const { apiStore } = await mountApp();
+    apiStore.apiToken = token;
+
+    await vi.advanceTimersByTimeAsync(FIFTY_NINE_MINUTES_MS);
+
+    expect(apiService.refreshToken).toHaveBeenCalled();
+  });
+
+  it("applies the same monitoring/dialog behavior in treatment preview mode", async () => {
+    const { apiStore } = await mountApp({
+      treatmentPreviewData: {
+        preview: true,
+        experimentId: "1",
+        conditionId: "1",
+        treatmentId: "1",
+        previewId: "1",
+        ownerId: "1"
+      }
+    });
+    apiStore.apiToken = expiredToken();
+
+    foregroundTab();
+    await flushPromises();
+
+    expect(Swal.fire).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears stale localStorage keys on mount but preserves quiz-draft keys", async () => {
+    localStorage.setItem("terracotta-api", "stale-token");
+    localStorage.setItem("terracotta-quiz-draft-1-2", "{}");
+
+    await mountApp();
+
+    expect(localStorage.getItem("terracotta-api")).toBeNull();
+    expect(localStorage.getItem("terracotta-quiz-draft-1-2")).toBe("{}");
+  });
+});

--- a/src/main/javascript/src/App.vue
+++ b/src/main/javascript/src/App.vue
@@ -140,11 +140,13 @@ import {
   ref,
   computed,
   defineAsyncComponent,
+  nextTick,
   onMounted,
   onBeforeUnmount
 } from "vue";
 
 import { useRoute } from "vue-router";
+import Swal from "sweetalert2";
 
 import Assignment from "@/views/obsolete/Assignment.vue";
 import Integrations from "@/views/integrations/Integrations.vue";
@@ -196,6 +198,9 @@ const childLoaded = ref(false);
 const integrationsTokenAlert = ref(null);
 
 let refreshInterval = null;
+let sessionExpired = false;
+let refreshInFlight = false; // avoid overlapping calls if the interval tick and a
+                              // visibilitychange fire close together
 
 // -------------------------------------
 // Pinia State
@@ -285,11 +290,64 @@ const showSkipLink = computed(() => {
 // -------------------------------------
 
 const refreshToken = () => {
-  return apiStore.refreshToken(apiToken.value);
+  return apiStore.refreshToken();
 };
 
 const retrieveConfiguration = () => {
   return configurationStore.retrieve();
+};
+
+// clears stale persisted state (e.g. pinia-plugin-persistedstate's auth token) on every
+// fresh mount, without wiping StudentQuiz.vue's draft-answer safety net keys, which need
+// to survive exactly the relaunch this mount represents
+const clearStaleStorageExceptDrafts = () => {
+  const draftPrefix = "terracotta-quiz-draft-";
+
+  Object.keys(localStorage)
+    .filter(key => !key.startsWith(draftPrefix))
+    .forEach(key => localStorage.removeItem(key));
+};
+
+const stopTokenMonitoring = () => {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
+};
+
+const checkAndRefreshToken = async () => {
+  if (sessionExpired || refreshInFlight || !apiToken.value) {
+    return;
+  }
+
+  if (apiStore.isApiTokenExpired()) {
+    sessionExpired = true;
+    stopTokenMonitoring();
+    apiStore.markSessionExpired();
+    await nextTick(); // let StudentQuiz.vue's draft-save watcher react first
+
+    await Swal.fire(
+      "Your session has expired. Please return to your course and re-open this assignment to continue."
+    );
+
+    return;
+  }
+
+  refreshInFlight = true;
+
+  try {
+    await refreshToken();
+  } finally {
+    refreshInFlight = false;
+  }
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === "visible") {
+    checkAndRefreshToken();
+  }
 };
 
 // -------------------------------------
@@ -297,21 +355,21 @@ const retrieveConfiguration = () => {
 // -------------------------------------
 
 onMounted(async () => {
-  localStorage.clear();
+  clearStaleStorageExceptDrafts();
 
   if (!isTreatmentPreview.value) {
     await retrieveConfiguration();
   }
 
   refreshInterval = window.setInterval(() => {
-    refreshToken();
+    checkAndRefreshToken();
   }, 1000 * 60 * 59);
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
 });
 
 onBeforeUnmount(() => {
-  if (refreshInterval) {
-    clearInterval(refreshInterval);
-  }
+  stopTokenMonitoring();
 });
 </script>
 

--- a/src/main/javascript/src/store/api.module.js
+++ b/src/main/javascript/src/store/api.module.js
@@ -14,7 +14,8 @@ export const api = defineStore("api", {
     assignmentId: "",
     consent: "",
     userId: "",
-    lmsApiOAuthURL: ""
+    lmsApiOAuthURL: "",
+    sessionExpired: false
   }),
 
   getters: {
@@ -34,6 +35,28 @@ export const api = defineStore("api", {
       this.consent = decodedToken.consent || "";
       this.userId = decodedToken.userId || "";
       this.userInfo = userInfo(decodedToken.roles || []);
+    },
+
+    // must be a plain method, not a getter - a getter is a cached computed() that
+    // wouldn't change once evaluated, but this check is time-based (Date.now()) and
+    // needs to be re-evaluated fresh on every call
+    isApiTokenExpired() {
+      if (!this.apiToken) {
+        return false; // no token yet - nothing to call "expired"
+      }
+
+      try {
+        const { exp } = jwtDecode(this.apiToken);
+
+        return typeof exp === "number" && exp * 1000 <= Date.now();
+      } catch (error) {
+        console.error("api/isApiTokenExpired | catch", error);
+        return true; // can't decode it - treat as unusable, fail safe
+      }
+    },
+
+    markSessionExpired() {
+      this.sessionExpired = true;
     },
 
     async setLtiToken(token) {

--- a/src/main/javascript/src/store/api.module.spec.js
+++ b/src/main/javascript/src/store/api.module.spec.js
@@ -172,6 +172,42 @@ describe("api store", () => {
     consoleSpy.mockRestore();
   });
 
+  describe("isApiTokenExpired", () => {
+    it("returns false when apiToken is empty", () => {
+      expect(store.apiToken).toBe("");
+      expect(store.isApiTokenExpired()).toBe(false);
+    });
+
+    it("returns false for a token with a future exp", () => {
+      store.apiToken = makeToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+
+      expect(store.isApiTokenExpired()).toBe(false);
+    });
+
+    it("returns true for a token with a past exp", () => {
+      store.apiToken = makeToken({ exp: Math.floor(Date.now() / 1000) - 3600 });
+
+      expect(store.isApiTokenExpired()).toBe(true);
+    });
+
+    it("returns true and logs when the token can't be decoded", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      store.apiToken = "not-a-real-jwt";
+
+      expect(store.isApiTokenExpired()).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  it("markSessionExpired sets sessionExpired to true", () => {
+    expect(store.sessionExpired).toBe(false);
+
+    store.markSessionExpired();
+
+    expect(store.sessionExpired).toBe(true);
+  });
+
   it("reportStep resolves with the service's response", async () => {
     apiService.reportStep.mockResolvedValue({ status: 200 });
 

--- a/src/main/javascript/src/test-utils/mockLocalStorage.js
+++ b/src/main/javascript/src/test-utils/mockLocalStorage.js
@@ -1,0 +1,40 @@
+// jsdom's window.localStorage is unavailable in this project's test environment (likely an
+// origin/config quirk - Storage is origin-scoped and jsdom's default test origin doesn't
+// satisfy it), so tests exercising code that reads/writes localStorage need this stubbed in.
+// Mirrors real Storage semantics closely enough for that: getItem/setItem/removeItem/clear,
+// and stored keys are real enumerable own properties so Object.keys(localStorage) works too
+// (production code, e.g. App.vue's clearStaleStorageExceptDrafts, relies on that).
+export function createMockLocalStorage(initial = {}) {
+  const storage = { ...initial };
+
+  // configurable: true so tests can vi.spyOn() these methods (e.g. to simulate a browser
+  // blocking storage access)
+  Object.defineProperties(storage, {
+    getItem: {
+      value: key => (Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null),
+      enumerable: false,
+      configurable: true,
+      writable: true
+    },
+    setItem: {
+      value: (key, value) => { storage[key] = String(value); },
+      enumerable: false,
+      configurable: true,
+      writable: true
+    },
+    removeItem: {
+      value: key => { delete storage[key]; },
+      enumerable: false,
+      configurable: true,
+      writable: true
+    },
+    clear: {
+      value: () => { Object.keys(storage).forEach(key => delete storage[key]); },
+      enumerable: false,
+      configurable: true,
+      writable: true
+    }
+  });
+
+  return storage;
+}

--- a/src/main/javascript/src/views/student/quiz/StudentQuiz.spec.js
+++ b/src/main/javascript/src/views/student/quiz/StudentQuiz.spec.js
@@ -45,6 +45,7 @@ import {
   previewService
 } from "@/services";
 import { mountComponent } from "@/test-utils/mount";
+import { api as apiModule } from "@/store/api.module";
 import StudentQuiz from "./StudentQuiz.vue";
 
 const stubbedChildren = {
@@ -314,6 +315,124 @@ describe("StudentQuiz", () => {
     );
 
     expect(wrapper.text()).toContain("Your answers have been submitted.");
+    expect(localStorage.getItem("terracotta-quiz-draft-1-103")).toBeNull();
+  });
+
+  describe("data-loss safety net: draft answers", () => {
+    it("saves the current answers to localStorage when the session expires", async () => {
+      mockReportStepByStep();
+
+      const wrapper = mountComponent(StudentQuiz, {
+        props: { experimentId: "1" },
+        global: { stubs: stubbedChildren }
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      const questionCard = wrapper.findComponent({ name: "StudentQuizQuestionCard" });
+      await questionCard.vm.$emit("update:question-values", [
+        { questionId: 10, answerId: 100, response: null }
+      ]);
+      await flushPromises();
+
+      const apiStore = apiModule();
+      apiStore.markSessionExpired();
+      await flushPromises();
+
+      const draft = JSON.parse(localStorage.getItem("terracotta-quiz-draft-1-103"));
+      expect(draft.questionValues).toEqual([
+        { questionId: 10, answerId: 100, response: null }
+      ]);
+    });
+
+    it("offers to restore a matching draft on load and repopulates answers when confirmed", async () => {
+      localStorage.setItem("terracotta-quiz-draft-1-103", JSON.stringify({
+        questionValues: [{ questionId: 10, answerId: 100, response: null }],
+        savedAt: Date.now()
+      }));
+      mockReportStepByStep();
+
+      const wrapper = mountComponent(StudentQuiz, {
+        props: { experimentId: "1" },
+        global: { stubs: stubbedChildren }
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      expect(Swal.fire).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "We found unsaved answers from your last session. Would you like to restore them?" })
+      );
+
+      const questionCard = wrapper.findComponent({ name: "StudentQuizQuestionCard" });
+      expect(questionCard.props("questionValues")).toEqual([
+        { questionId: 10, answerId: 100, response: null }
+      ]);
+      expect(localStorage.getItem("terracotta-quiz-draft-1-103")).toBeNull();
+    });
+
+    it("leaves fresh blank answers and still clears the draft when the restore prompt is declined", async () => {
+      localStorage.setItem("terracotta-quiz-draft-1-103", JSON.stringify({
+        questionValues: [{ questionId: 10, answerId: 100, response: null }],
+        savedAt: Date.now()
+      }));
+      Swal.fire.mockResolvedValueOnce({ isConfirmed: false });
+      mockReportStepByStep();
+
+      const wrapper = mountComponent(StudentQuiz, {
+        props: { experimentId: "1" },
+        global: { stubs: stubbedChildren }
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      const questionCard = wrapper.findComponent({ name: "StudentQuizQuestionCard" });
+      expect(questionCard.props("questionValues")).toEqual([
+        { questionId: 10, answerId: null, response: null }
+      ]);
+      expect(localStorage.getItem("terracotta-quiz-draft-1-103")).toBeNull();
+    });
+
+    it("discards a draft for a different question set without prompting", async () => {
+      localStorage.setItem("terracotta-quiz-draft-1-103", JSON.stringify({
+        questionValues: [{ questionId: 999, answerId: 5, response: null }],
+        savedAt: Date.now()
+      }));
+      mockReportStepByStep();
+
+      mountComponent(StudentQuiz, {
+        props: { experimentId: "1" },
+        global: { stubs: stubbedChildren }
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      expect(Swal.fire).not.toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining("unsaved answers") })
+      );
+      expect(localStorage.getItem("terracotta-quiz-draft-1-103")).toBeNull();
+    });
+
+    it("does not crash when localStorage access throws", async () => {
+      const getItemSpy = vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+        throw new Error("blocked");
+      });
+      mockReportStepByStep();
+
+      const wrapper = mountComponent(StudentQuiz, {
+        props: { experimentId: "1" },
+        global: { stubs: stubbedChildren }
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: "StudentQuizQuestionCard" }).exists()).toBe(true);
+      getItemSpy.mockRestore();
+    });
   });
 
   it("delegates file downloads from the question card to the submission store and clears the in-flight id", async () => {

--- a/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
+++ b/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
@@ -260,10 +260,82 @@ watch(selectedSubmissionId, () => {
   }
 });
 
-watch(answerableQuestions, questions => {
-  questionValues.value = questions
+// data-loss safety net: there's no autosave in this app, and telling a student their
+// session expired means they have to relaunch, which would otherwise throw away
+// whatever they'd typed since their last submit. draftStorageKey is keyed by
+// experimentId + assessmentId (not submissionId, which may not be stable across a
+// relaunch) - see saveDraftAnswers/clearDraftAnswers and the answerableQuestions
+// watch below for the restore side.
+const draftStorageKey = computed(() => `terracotta-quiz-draft-${props.experimentId}-${assessmentId.value}`);
+
+const saveDraftAnswers = () => {
+  try {
+    localStorage.setItem(
+      draftStorageKey.value,
+      JSON.stringify({ questionValues: questionValues.value, savedAt: Date.now() })
+    );
+  } catch (error) {
+    // e.g. storage blocked (cross-site iframe privacy restrictions) or full - fail
+    // silently, there's nothing more we can do
+    console.error("StudentQuiz/saveDraftAnswers | catch", error);
+  }
+};
+
+const clearDraftAnswers = () => {
+  try {
+    localStorage.removeItem(draftStorageKey.value);
+  } catch (error) {
+    console.error("StudentQuiz/clearDraftAnswers | catch", error);
+  }
+};
+
+watch(() => apiStore.sessionExpired, expired => {
+  if (expired) saveDraftAnswers();
+});
+
+watch(answerableQuestions, async questions => {
+  const freshValues = questions
     .filter(q => q.questionType !== "INTEGRATION")
     .map(q => ({ questionId: q.questionId, answerId: null, response: null }));
+
+  questionValues.value = freshValues;
+
+  let draft = null;
+
+  try {
+    draft = JSON.parse(localStorage.getItem(draftStorageKey.value) || "null");
+  } catch (error) {
+    console.error("StudentQuiz/restoreDraftAnswers | catch", error);
+  }
+
+  if (!draft?.questionValues?.length) {
+    return;
+  }
+
+  const freshIds = new Set(freshValues.map(q => q.questionId));
+
+  if (!draft.questionValues.some(q => freshIds.has(q.questionId))) {
+    clearDraftAnswers(); // draft is for a different/stale question set - discard, don't offer it
+    return;
+  }
+
+  const result = await Swal.fire({
+    target: "#app",
+    icon: "question",
+    text: "We found unsaved answers from your last session. Would you like to restore them?",
+    showCancelButton: true,
+    confirmButtonText: "Yes, restore",
+    cancelButtonText: "No, start fresh"
+  });
+
+  if (result.isConfirmed) {
+    questionValues.value = freshValues.map(q => {
+      const saved = draft.questionValues.find(d => d.questionId === q.questionId);
+      return saved ? { ...q, answerId: saved.answerId, response: saved.response } : q;
+    });
+  }
+
+  clearDraftAnswers();
 });
 
 watch(integrationTokenExpirationRemaining, newValue => {
@@ -335,6 +407,7 @@ const submitQuiz = async () => {
     if (view?.status === 200) {
       assignmentData.value = view.data;
       submitted.value = true;
+      clearDraftAnswers();
     }
   } catch (error) {
     submissions.value = null;

--- a/src/main/javascript/vitest.setup.js
+++ b/src/main/javascript/vitest.setup.js
@@ -1,7 +1,15 @@
-import { afterEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import { enableAutoUnmount } from "@vue/test-utils";
 
+import { createMockLocalStorage } from "@/test-utils/mockLocalStorage";
+
 enableAutoUnmount(afterEach);
+
+// jsdom's window.localStorage is unavailable in this environment; stub a fresh one before
+// every test so tests are isolated from one another and code under test never sees undefined
+beforeEach(() => {
+  vi.stubGlobal("localStorage", createMockLocalStorage());
+});
 
 window.ResizeObserver = window.ResizeObserver || class ResizeObserver {
   observe() {}


### PR DESCRIPTION
## Summary
- A production log review turned up several hundred `WARN ... ApiJwtServiceImpl - JWT expired` entries. `App.vue` refreshed the 1-hour student session token every 59 minutes via a blind `setInterval`, but browsers throttle/delay that timer on backgrounded tabs (switched away, phone locked, laptop sleeps), so the refresh can fire after the token has already expired. Once that happens the refresh is rejected (by design), the failure was dropped silently with no retry/message, and the token stayed permanently stuck - the interval kept firing every 59 minutes forever, always failing, and any real student action (saving, submitting) also failed silently against the dead token.
- Confirmed a page reload does **not** recover the session: the token is persisted to `localStorage` and rehydrates before `onMounted` runs, so a reload just reloads the same dead token. The only real recovery is a fresh LTI launch from the LMS.
- Added a client-side expiry check (`api.module.js`'s `isApiTokenExpired`) and drive the refresh from a `visibilitychange` listener in addition to the baseline interval, so a throttled timer gets caught the moment the tab is foregrounded again, before it drifts past expiry.
- When the token is genuinely dead, tell the student clearly to return to their course and re-open the assignment (not "reload the page," since that doesn't help), then stop monitoring so it can't keep hammering the backend or re-showing the dialog.
- Since there's no autosave in this app and relaunching would otherwise throw away whatever the student had answered since their last submit, save their current in-progress answers to `localStorage` right before showing that message, and offer to restore them on their next launch (`StudentQuiz.vue`).

## Test plan
- [x] Full frontend suite passes (1548 tests, 176 files)
- [x] `eslint .` clean
- [x] Production build (`yarn build`) succeeds
- [x] Full backend suite passes (unaffected, frontend-only change)
- New coverage: `api.module.spec.js` (`isApiTokenExpired`, `markSessionExpired`), `App.spec.js` (new - refresh/visibility monitoring, session-expired dialog, selective storage clear), `StudentQuiz.spec.js` (draft save/restore/discard/error-handling)