### PR TITLE
NO_JIRA - don't let a failed consent grade post block recording consent

### DIFF
--- a/src/main/java/edu/iu/terracotta/controller/app/ParticipantController.java
+++ b/src/main/java/edu/iu/terracotta/controller/app/ParticipantController.java
@@ -155,7 +155,12 @@ public class ParticipantController {
             try {
                 participantService.postConsentSubmission(participant, securedInfo);
             } catch (ConnectionException e) {
-                throw new RuntimeException("Failed to post grade to the LMS for consent submission", e);
+                // don't let a failed grade sync (e.g. the LMS rejecting it because the consent
+                // assignment's attempt limit was already reached) block the student from
+                // recording their actual consent decision below - the two are independent
+                // outcomes, and the student shouldn't be stuck unable to consent over a
+                // gradebook sync issue
+                log.warn("Failed to post grade to the LMS for consent submission for participant ID: [{}]", participantId, e);
             }
 
             try {

--- a/src/test/java/edu/iu/terracotta/controller/app/ParticipantControllerTest.java
+++ b/src/test/java/edu/iu/terracotta/controller/app/ParticipantControllerTest.java
@@ -186,13 +186,22 @@ public class ParticipantControllerTest extends BaseTest {
     }
 
     @Test
-    void updateParticipantLearnerConnectionExceptionWrappedTest() throws Exception {
+    void updateParticipantLearnerConnectionExceptionDoesNotBlockConsentTest() throws Exception {
+        // a failed grade sync to the LMS (e.g. Canvas rejecting it because the consent
+        // assignment's attempt limit was already reached) must not prevent the student's
+        // actual consent decision from being recorded - the two are independent outcomes
         when(apiJwtService.isInstructorOrHigher(securedInfo)).thenReturn(false);
         when(apiJwtService.isLearner(securedInfo)).thenReturn(true);
         when(participantService.getParticipant(2L, 1L, USER_ID, true)).thenReturn(participant);
         doThrow(new ConnectionException("lms down")).when(participantService).postConsentSubmission(participant, securedInfo);
+        when(participantService.changeConsent(participantDto, securedInfo, 1L)).thenReturn(participant);
+        when(participantService.toDto(participant, securedInfo)).thenReturn(participantDto);
 
-        assertThrows(RuntimeException.class, () -> participantController.updateParticipant(1L, 2L, participantDto, httpServletRequest));
+        ResponseEntity<ParticipantDto> response = participantController.updateParticipant(1L, 2L, participantDto, httpServletRequest);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(participantDto, response.getBody());
+        verify(participantService).changeConsent(participantDto, securedInfo, 1L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ParticipantController.updateParticipant` always tries to post a grade to the LMS for the consent assignment, then separately records the student's actual consent decision via `changeConsent`. A failed grade post (e.g. Canvas rejecting it with `422 "The maximum number of allowed attempts has been reached for this submission"`) was caught only to be rethrown as an uncaught `RuntimeException`, which skipped `changeConsent` entirely and produced an uncaught 500.
- Root cause of the Canvas rejection itself is legitimate (Canvas's own attempt-limit business rule, not a Terracotta bug) - the actual problem is that Terracotta let a grade-sync failure block the student's consent from ever being recorded, leaving them stuck unable to proceed into the experiment over something unrelated to whether they'd actually consented.
- Fix: log the grade-post failure and continue to `changeConsent` regardless - the two outcomes (grade synced to the LMS, consent recorded) are independent, and only one of them should gate the student's ability to continue.

## Test plan
- [x] `ParticipantControllerTest` passes (19 tests), including an updated test asserting consent is still recorded when the grade post fails
- [x] Full backend suite passes (4047 tests, 0 failures)