### PR TITLE
NO_JIRA - disable the Actuator mail health indicator (checks an unused SMTP path)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,16 @@ server:
   # since a too-small value fails silently as this exact "Request header is too large" error.
   max-http-header-size: 32KB
 
+management:
+  health:
+    mail:
+      # spring-boot-starter-mail's JavaMailSender is only used here to build MimeMessage
+      # objects (see MessageEmailServiceImpl); actual delivery goes through AWS SES, not
+      # SMTP, so this indicator's default localhost:25 connectivity check is meaningless -
+      # it was failing the health endpoint (and flooding the log) for a transport nothing
+      # actually sends through.
+      enabled: false
+
 # if true, it will display the LTI messages and never jump to the app part. Set to false for prod.
 lti13:
   demoMode: true


### PR DESCRIPTION
## Summary
- `spring-boot-starter-mail`'s `JavaMailSender` is only used to build `MimeMessage` objects (see `MessageEmailServiceImpl` - `.createMimeMessage()` is called, `.send()` never is). Actual email delivery goes entirely through AWS SES.
- With no `spring.mail.host` configured, Spring Boot Actuator's auto-registered mail health indicator defaults to testing SMTP connectivity to `localhost:25`, which predictably fails and logs a `WARN` + full stack trace on every health check - for a transport nothing actually sends through.
- Disable that specific indicator (`management.health.mail.enabled: false`) rather than configuring a fake/dummy SMTP host just to satisfy it.

## Test plan
- [x] Full backend suite passes (4047 tests, 0 failures) - confirms the YAML is valid and the Spring context still loads cleanly