### PR TITLE
Use a real measured fallback height instead of a flat 600px guess

### DIFF
--- a/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.spec.js
+++ b/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { mountComponent } from "@/test-utils/mount";
 import StudentQuizIntegration from "./StudentQuizIntegration.vue";
@@ -30,6 +30,57 @@ describe("StudentQuizIntegration", () => {
     await wrapper.setProps({ hasResizeMessage: true });
 
     expect(wrapper.find("iframe").classes()).not.toContain("no-resize");
+  });
+
+  describe("fallback height (before a resize message arrives)", () => {
+    const originalInnerHeight = window.innerHeight;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      Object.defineProperty(window, "innerHeight", { value: originalInnerHeight, configurable: true });
+    });
+
+    // real content height is unknown until the embedded tool posts a resize message
+    // (which - see StudentQuizIntegration.vue's own comment - isn't guaranteed to
+    // ever happen at all), so in the meantime the iframe is sized to whatever
+    // viewport space is actually left below it, not a fixed guess.
+    it("sizes the iframe to the remaining viewport space below it", async () => {
+      const wrapper = mountComponent(StudentQuizIntegration, {
+        props: { assessment, integration, hasResizeMessage: false }
+      });
+
+      Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
+      vi.spyOn(wrapper.find("iframe").element, "getBoundingClientRect").mockReturnValue({ top: 200 });
+      window.dispatchEvent(new Event("resize"));
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find("iframe").attributes("style")).toContain("height: 700px");
+    });
+
+    it("clamps to a sane minimum instead of collapsing when little viewport room is left", async () => {
+      const wrapper = mountComponent(StudentQuizIntegration, {
+        props: { assessment, integration, hasResizeMessage: false }
+      });
+
+      Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
+      vi.spyOn(wrapper.find("iframe").element, "getBoundingClientRect").mockReturnValue({ top: 850 });
+      window.dispatchEvent(new Event("resize"));
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find("iframe").attributes("style")).toContain("height: 300px");
+    });
+
+    it("clears the inline height once a resize message has arrived, leaving the embedded tool's own real height in control", async () => {
+      const wrapper = mountComponent(StudentQuizIntegration, {
+        props: { assessment, integration, hasResizeMessage: false }
+      });
+
+      expect(wrapper.find("iframe").attributes("style")).toContain("height");
+
+      await wrapper.setProps({ hasResizeMessage: true });
+
+      expect(wrapper.find("iframe").attributes("style")).toBeFalsy();
+    });
   });
 
   it("renders the IntegrationFeedback component with the selected submission when readonly", () => {

--- a/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.vue
+++ b/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.vue
@@ -11,8 +11,10 @@
       <iframe
         v-if="!readonly"
         id="integration-iframe"
+        ref="iframeEl"
         :src="integration.launchUrl"
         :class="{ 'no-resize': !hasResizeMessage }"
+        :style="hasResizeMessage ? {} : { height: `${fallbackHeight}px` }"
         title="student assignment"
         aria-label="student assignment"
       />
@@ -34,6 +36,7 @@
 </template>
 
 <script setup>
+import { ref, onMounted, onBeforeUnmount } from "vue";
 import ExternalIntegrationResponseEditor from "@/views/integrations/ExternalIntegrationResponseEditor.vue";
 
 defineProps({
@@ -44,37 +47,96 @@ defineProps({
   selectedSubmission: { type: Object, default: null },
   hasResizeMessage: { type: Boolean, default: false }
 });
+
+const iframeEl = ref(null);
+// a sane guess for the very first paint, before onMounted's real measurement runs -
+// see measureFallbackHeight's own comment for why this can't just be a fixed value
+// generally.
+const fallbackHeight = ref(400);
+let resizeObserver = null;
+
+// Keeps this iframe's own contribution to the page's height bounded to whatever
+// vertical space is actually left below it in the viewport, so the fallback used
+// before the embedded tool posts its real resize message (handleIntegrationsResize in
+// StudentQuiz.vue) can't itself push this document taller than one viewport - which
+// is exactly what caused the double-scrollbar bug a flat CSS min-height had (see this
+// file's git history). A fixed px guess can't adapt to that: how much banner/
+// instruction content renders above this iframe varies (retake banner, submission
+// details, the assessment intro html above), and so does the viewport itself.
+//
+// This matters even more for any integration that never sends a resize message at
+// all - the resize-observer scripts under public/js/integrations/resize/ are
+// something the integration's OWN author has to add on their end; nothing here can
+// assume they did. For those, this isn't a brief loading state, it's the iframe's
+// height for the rest of the session, so it needs to be a reasonable real size, not
+// just "not broken for a moment."
+const measureFallbackHeight = () => {
+  if (!iframeEl.value) {
+    return;
+  }
+
+  const MIN_HEIGHT = 300; // still usable if something above pushes this near/past the fold
+  const top = iframeEl.value.getBoundingClientRect().top;
+
+  fallbackHeight.value = Math.max(window.innerHeight - top, MIN_HEIGHT);
+};
+
+onMounted(() => {
+  measureFallbackHeight();
+  // catches both viewport resizes and layout shifts from content elsewhere on the
+  // page (a banner appearing/disappearing, the assessment intro html rendering) -
+  // observing document.body is broad on purpose, since enumerating every possible
+  // cause of "content above this iframe changed height" isn't practical.
+  resizeObserver = new ResizeObserver(measureFallbackHeight);
+  resizeObserver.observe(document.body);
+  window.addEventListener("resize", measureFallbackHeight);
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  window.removeEventListener("resize", measureFallbackHeight);
+});
 </script>
 
 <style lang="scss" scoped>
 .integration {
-  min-height: 100%;
   min-width: 100%;
 
+  // no min-height here (or on .v-col below) - Vuetify's v-application renders with
+  // its "full-height" layout mode, which this row/col's own min-height: 100% used to
+  // resolve against regardless of how much space any PRECEDING sibling content
+  // (retake banner, submission details, etc. in StudentQuiz.vue) already used above
+  // it. That's a second, independent way this page's total height could end up
+  // taller than one viewport - confirmed via a standalone reproduction with a
+  // stand-in "banner" div above this component: even with the iframe itself sized
+  // exactly to the remaining viewport space (see measureFallbackHeight's comment
+  // above), this row/col still inflated to a FULL extra viewport-height's worth of
+  // space on top of that banner, because min-height: 100% doesn't know or care what
+  // else is already on the page. Without it, this area sizes to its own content
+  // (the iframe's own height, which is already correctly computed) instead of
+  // fighting it.
   & > .v-col {
-    min-height: 100%;
     min-width: 100%;
 
     & > iframe {
+      // an iframe defaults to display: inline, which sits it on a text baseline and
+      // reserves a few extra px below it for descenders (the same "mystery gap
+      // under an image" quirk that comes up whenever an inline-replaced element
+      // sits in a block context) - block avoids that, so this element's own
+      // measured height (see measureFallbackHeight above) is really all the extra
+      // vertical space its container ends up needing.
+      display: block;
       min-width: 100%;
       border: none;
     }
   }
 
-  // before the embedded tool posts its resize message (handleIntegrationsResize in
-  // StudentQuiz.vue), we don't know its real content height yet. This used to fall
-  // back to min-height: 100vh, but that measures against THIS document's own
-  // viewport - stacked on top of whatever else is already on the page (retake
-  // banner, submission details, etc.), it guaranteed this document's total height
-  // exceeded one viewport, which is exactly what produced the reported double
-  // scrollbar: this document needing to scroll AND the LMS's outer iframe (not yet
-  // told to resize, since that only happens once the message arrives) also needing
-  // to scroll to show all of it. A fixed, modest default has no such guarantee -
-  // worst case the iframe's own content needs to scroll internally for the brief
-  // window before the real height arrives, which is far less disruptive than the
-  // whole page reliably overflowing on every load.
-  & .no-resize {
-    min-height: 600px;
-  }
+  // .no-resize itself carries no height rule any more - the fallback height is set
+  // as an inline style computed by measureFallbackHeight() in the script above (a
+  // fixed CSS value, like the min-height: 100vh this used to be, can't adapt to how
+  // much banner/instruction content is actually rendered above this iframe or to the
+  // viewport size, and reliably guessed wrong in a way that caused a double
+  // scrollbar - see that function's comment). The class stays as a hook for
+  // tests/styling to key off "we don't have a real height yet" if needed.
 }
 </style>


### PR DESCRIPTION
The previous fix (min-height: 100vh -> 600px) avoided guaranteeing overflow, but a fixed px value still can't adapt to how much banner/ instruction content actually renders above this iframe or to the viewport size - and for any integration that never sends a resize message at all (the resize-observer scripts under
public/js/integrations/resize/ are something the integration author has to add on their own end, not something Terracotta injects), this isn't a brief loading state, it's the iframe's height for the rest of the session.

Measure the actual remaining viewport space below the iframe instead (window.innerHeight - its own getBoundingClientRect().top, clamped to a sane minimum), re-measuring on viewport resize and on any layout change elsewhere on the page via a ResizeObserver on document.body.

Fixing this exposed two more independent contributors to the same double-scrollbar symptom, found via a standalone reproduction:
- .integration/.v-col's own min-height: 100% resolved against Vuetify's full-height app layout regardless of how much space preceding sibling content (banners) already used, inflating this area by a full extra viewport's worth of space on top of that - removed now that the iframe sizes itself correctly.
- The iframe's default display: inline reserved a few px below it for text descenders (the classic "gap under an image" quirk) - display: block removes that.