### PR TITLE
Ask the LMS to resize its own iframe to fit the page, app-wide

### DIFF
--- a/src/main/javascript/src/App.spec.js
+++ b/src/main/javascript/src/App.spec.js
@@ -186,4 +186,44 @@ describe("App", () => {
     expect(localStorage.getItem("terracotta-api")).toBeNull();
     expect(localStorage.getItem("terracotta-quiz-draft-1-2")).toBe("{}");
   });
+
+  describe("frame resize reporting (lti.frameResize)", () => {
+    const originalTop = window.top;
+
+    afterEach(() => {
+      Object.defineProperty(window, "top", { value: originalTop, configurable: true });
+    });
+
+    it("does not report a height to the parent when not embedded in an iframe", async () => {
+      const postMessageSpy = vi.spyOn(window, "postMessage");
+
+      await mountApp();
+
+      expect(postMessageSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ subject: "lti.frameResize" }),
+        "*"
+      );
+    });
+
+    it("reports the real measured page height to the parent LMS on mount when embedded in an iframe", async () => {
+      Object.defineProperty(window, "top", { value: {}, configurable: true });
+      Object.defineProperty(document.body, "offsetHeight", { value: 1234, configurable: true });
+      Object.defineProperty(document.documentElement, "offsetHeight", { value: 1000, configurable: true });
+      const postMessageSpy = vi.spyOn(window.parent, "postMessage");
+
+      await mountApp();
+
+      expect(postMessageSpy).toHaveBeenCalledWith({ subject: "lti.frameResize", height: 1234 }, "*");
+    });
+
+    it("stops reporting once unmounted", async () => {
+      Object.defineProperty(window, "top", { value: {}, configurable: true });
+      const disconnectSpy = vi.spyOn(ResizeObserver.prototype, "disconnect");
+
+      const { wrapper } = await mountApp();
+      wrapper.unmount();
+
+      expect(disconnectSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/main/javascript/src/App.vue
+++ b/src/main/javascript/src/App.vue
@@ -308,6 +308,53 @@ const clearStaleStorageExceptDrafts = () => {
     .forEach(key => localStorage.removeItem(key));
 };
 
+// Tells the LMS platform (Canvas et al - this is the standard LTI Platform Messages
+// postMessage subject, not Terracotta-specific) how tall this page actually is, so it
+// can size ITS OWN iframe (the one wrapping the whole Terracotta tool) to fit,
+// instead of leaving it at whatever default height the platform picked. Without
+// this, that outer iframe can end up shorter than Terracotta's real content, which
+// means a second, outer scrollbar on top of whatever's already inside the tool - the
+// same double-scrollbar failure mode already fixed for the student integration
+// quiz's own nested iframe, just one level up. This runs for every page in the app
+// (not just that one flow), reacting to any layout change, not just the cases that
+// happen to already have their own resize handling.
+//
+// Matches the height calculation the resize-observer scripts under
+// public/js/integrations/resize/ already use on the OTHER side of a similar handshake
+// (an embedded integration tool reporting ITS size to Terracotta), for consistency.
+let frameResizeObserver = null;
+
+const isEmbeddedInAnIframe = () => {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // a cross-origin parent throws on window.top access in some browsers - if we
+    // can't tell, assume embedded, since that's the case this exists for
+    return true;
+  }
+};
+
+const notifyParentOfHeight = () => {
+  const height = Math.max(document.body.offsetHeight, document.documentElement.offsetHeight);
+
+  window.parent.postMessage({ subject: "lti.frameResize", height }, "*");
+};
+
+const startFrameResizeReporting = () => {
+  if (!isEmbeddedInAnIframe()) {
+    return;
+  }
+
+  notifyParentOfHeight();
+  frameResizeObserver = new ResizeObserver(notifyParentOfHeight);
+  frameResizeObserver.observe(document.body);
+};
+
+const stopFrameResizeReporting = () => {
+  frameResizeObserver?.disconnect();
+  frameResizeObserver = null;
+};
+
 const stopTokenMonitoring = () => {
   if (refreshInterval) {
     clearInterval(refreshInterval);
@@ -366,10 +413,12 @@ onMounted(async () => {
   }, 1000 * 60 * 59);
 
   document.addEventListener("visibilitychange", handleVisibilityChange);
+  startFrameResizeReporting();
 });
 
 onBeforeUnmount(() => {
   stopTokenMonitoring();
+  stopFrameResizeReporting();
 });
 </script>
 

--- a/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
+++ b/src/main/javascript/src/views/student/quiz/StudentQuiz.vue
@@ -543,7 +543,11 @@ const handleIntegrationsResize = event => {
     const iframe = document.getElementById("integration-iframe");
     if (!iframe || iframe.height === event.data.height) return;
     iframe.height = `${event.data.height}px`;
-    window.parent.postMessage({ subject: "lti.frameResize", height: event.data.height + 200 }, "*");
+    // no longer posting lti.frameResize to the LMS parent here directly - App.vue's
+    // ResizeObserver on document.body picks up the resulting layout change (this
+    // iframe growing/shrinking) and reports the real measured page height itself,
+    // for every page in the app, not just this one flow. That's more accurate than
+    // this handler's own height + a flat 200px guess at surrounding chrome ever was.
   }
 };
 


### PR DESCRIPTION
StudentQuiz.vue already asked Canvas (lti.frameResize, the standard LTI Platform Messages postMessage subject) to resize its outer iframe, but only reactively, in response to the student integration quiz's own nested iframe reporting its size, and only by that height plus a flat +200px guess at surrounding chrome. Every other page in the app never asked at all, leaving Canvas's default iframe height to potentially fall short of the real content - the same double-scrollbar failure mode already fixed one level down for that nested iframe, just for the outer one this time.

Added a ResizeObserver on document.body in App.vue (the one root component every page mounts under) that reports the real measured page height on any layout change, for the whole app rather than one flow, using the same height calculation the resize-observer scripts under public/js/integrations/resize/ already use on the other side of a similar handshake. Only runs when actually embedded in an iframe (window.self !== window.top) - posting to a parent that doesn't exist is a no-op, but skipping it makes that explicit.

Removed the narrower, less accurate postMessage call from StudentQuiz.vue's handleIntegrationsResize now that the general reporter covers it (it still directly resizes its own nested iframe, which is unrelated and still needed).