### PR TITLE
Fix blank space below short pages in the resized outer iframe

### DIFF
--- a/src/main/javascript/src/styles/_global.scss
+++ b/src/main/javascript/src/styles/_global.scss
@@ -31,6 +31,17 @@ body {
   }
 }
 
+// Vuetify defaults .v-application to at least a full viewport tall, which made sense
+// when this app's outer iframe was a fixed/default height Canvas picked on its own.
+// Now that App.vue actively measures and reports document.body's real height so Canvas
+// can size that iframe to fit (see notifyParentOfHeight), this floor becomes
+// self-reinforcing instead: body can never report shorter than whatever height the
+// iframe already has, so a short page (e.g. the assignment/message editors) can never
+// shrink the iframe back down, leaving blank space below its real content.
+.v-application__wrap {
+  min-height: unset !important;
+}
+
 .v-tab__slider {
   background: #e0e0e0 !important;
 }

--- a/src/main/javascript/src/views/ExperimentSteps.vue
+++ b/src/main/javascript/src/views/ExperimentSteps.vue
@@ -284,7 +284,12 @@ onBeforeRouteUpdate(async (to, from, next) => {
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    height: 100vh;
+    // not height: 100vh - sticky positioning doesn't need it (the sidebar sticks
+    // within its grid area regardless), and forcing it here inflated the whole grid,
+    // and therefore document.body, to a full viewport tall on short pages (the
+    // assignment/message editors) even though their real content is much shorter -
+    // see the .v-application__wrap comment in _global.scss for the other half of this.
+    max-height: 100vh;
     grid-area: aside;
   }
 


### PR DESCRIPTION
Yesterday's outer-iframe resize work reports document.body's real height to Canvas so it can size the iframe to fit. Two long-standing rules independently floor that reported height to a full viewport regardless of actual content: Vuetify's own .v-application__wrap default (min-height: 100vh) and ExperimentSteps.vue's sticky sidebar (height: 100vh, used for its sticky positioning but not required by it). Neither mattered while Canvas picked the iframe's height on its own, but now the floor is self-reinforcing - body can never report shorter than the iframe's current height - leaving a permanent gap of blank space below genuinely short pages like the assignment and message editors, which live under that sidebar layout.