### PR TITLE
Validate the component name before creating or saving an assignment

### DIFF
--- a/src/main/javascript/src/views/assignment/AssignmentEditor.spec.js
+++ b/src/main/javascript/src/views/assignment/AssignmentEditor.spec.js
@@ -139,6 +139,37 @@ describe("AssignmentEditor", () => {
     expect(button.props("disabled")).toBe(true);
   });
 
+  it("disables the Continue button when the title is only whitespace", async () => {
+    assignmentService.fetchAssignment.mockResolvedValue({
+      assignmentId: 20,
+      title: "   "
+    });
+
+    const { wrapper } = mountEditor({ assignmentId: 20, title: "   " });
+    await wrapper.vm.$nextTick();
+    await new Promise(resolve => setTimeout(resolve));
+    await wrapper.vm.$nextTick();
+
+    const button = findContinueButton(wrapper);
+    expect(button.props("disabled")).toBe(true);
+  });
+
+  it("saveExit is a no-op when the title is only whitespace", async () => {
+    assignmentService.fetchAssignment.mockResolvedValue({
+      assignmentId: 20,
+      title: "   "
+    });
+
+    const { wrapper } = mountEditor({ assignmentId: 20, title: "   " });
+    await wrapper.vm.$nextTick();
+    await new Promise(resolve => setTimeout(resolve));
+
+    await wrapper.vm.saveExit();
+
+    expect(assignmentService.updateAssignment).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("enables Continue once a title is present and saves on click", async () => {
     assignmentService.fetchAssignment.mockResolvedValue({
       assignmentId: 20,

--- a/src/main/javascript/src/views/assignment/AssignmentEditor.vue
+++ b/src/main/javascript/src/views/assignment/AssignmentEditor.vue
@@ -4,6 +4,7 @@
       <v-col cols="6">
         <v-text-field
           v-model="title"
+          :rules="rules"
           label="Component name"
           variant="outlined"
         />
@@ -94,6 +95,15 @@ const alertStore = alertModule();
 
 const tab = ref("settings");
 
+const rules = [
+  value =>
+    value && !!value.trim() ||
+    "Component Name is required",
+  value =>
+    (value || "").length <= 255 ||
+    "A maximum of 255 characters is allowed"
+];
+
 const assignment = computed(() => {
   return assignmentStore.assignment;
 });
@@ -141,7 +151,7 @@ const resolvedExposureId = computed(() => {
 });
 
 const contDisabled = computed(() => {
-  return !assignment.value?.title;
+  return !assignment.value?.title?.trim();
 });
 
 const getSaveExitPage = computed(() => {

--- a/src/main/javascript/src/views/assignment/CreateAssignment.spec.js
+++ b/src/main/javascript/src/views/assignment/CreateAssignment.spec.js
@@ -98,6 +98,7 @@ describe("CreateAssignment", () => {
 
     const { wrapper, assignmentStore } = mountCreate();
     assignmentStore.setAssignment({ title: "My new assignment" });
+    await wrapper.vm.$nextTick();
 
     await wrapper.vm.saveExit();
     await new Promise(resolve => setTimeout(resolve));
@@ -121,11 +122,34 @@ describe("CreateAssignment", () => {
     });
   });
 
+  it("saveExit is a no-op and does not call the API when the title is blank", async () => {
+    const { wrapper } = mountCreate();
+
+    await wrapper.vm.saveExit();
+    await new Promise(resolve => setTimeout(resolve));
+
+    expect(assignmentService.create).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("saveExit is a no-op and does not call the API when the title is only whitespace", async () => {
+    const { wrapper, assignmentStore } = mountCreate();
+    assignmentStore.setAssignment({ title: "   " });
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.saveExit();
+    await new Promise(resolve => setTimeout(resolve));
+
+    expect(assignmentService.create).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("shows an error and does not navigate when assignment creation fails", async () => {
     assignmentService.create.mockResolvedValue({ status: 400, data: "bad" });
 
     const { wrapper, assignmentStore } = mountCreate();
     assignmentStore.setAssignment({ title: "My new assignment" });
+    await wrapper.vm.$nextTick();
 
     await wrapper.vm.saveExit();
     await new Promise(resolve => setTimeout(resolve));
@@ -141,7 +165,9 @@ describe("CreateAssignment", () => {
     // `response?.status !== 201` branch instead of the outer catch.
     assignmentService.create.mockRejectedValue(new Error("network down"));
 
-    const { wrapper } = mountCreate();
+    const { wrapper, assignmentStore } = mountCreate();
+    assignmentStore.setAssignment({ title: "My new assignment" });
+    await wrapper.vm.$nextTick();
 
     await wrapper.vm.saveExit();
     await new Promise(resolve => setTimeout(resolve));

--- a/src/main/javascript/src/views/assignment/CreateAssignment.vue
+++ b/src/main/javascript/src/views/assignment/CreateAssignment.vue
@@ -7,16 +7,18 @@
       be the way Terracotta will deliver treatments to students.
     </p>
 
-    <v-row>
-      <v-col cols="6">
-        <v-text-field
-          v-model="title"
-          :rules="rules"
-          label="Component name"
-          variant="outlined"
-        />
-      </v-col>
-    </v-row>
+    <v-form ref="form">
+      <v-row>
+        <v-col cols="6">
+          <v-text-field
+            v-model="title"
+            :rules="rules"
+            label="Component name"
+            variant="outlined"
+          />
+        </v-col>
+      </v-row>
+    </v-form>
 
     <v-divider />
 
@@ -83,6 +85,7 @@ const configurationStore = configurationModule();
 const alertStore = alertModule();
 
 const tab = ref("settings");
+const form = ref(null);
 
 const rules = [
   value =>
@@ -243,7 +246,13 @@ const createAssessmentForTreatment = async (
 };
 
 const saveExit = async () => {
-  await handleSaveAssignment();
+  const { valid } = await form.value.validate();
+
+  if (!valid) {
+    return false;
+  }
+
+  return await handleSaveAssignment();
 };
 
 onMounted(() => {


### PR DESCRIPTION
Neither CreateAssignment.vue nor AssignmentEditor.vue actually stopped a save with a blank title from reaching the LMS - the existing :rules were purely cosmetic, since nothing called validate() before saving, and AssignmentEditor's own disabled-button check missed a whitespace-only title (!" " is false). Canvas then rejects the empty name with IllegalArgumentException, surfacing as a 500 from AssignmentController.postAssignment.

CreateAssignment.vue now wraps the field in a v-form and validates it before saving; AssignmentEditor.vue trims before checking blankness and shows the same inline rule.