### PR TITLE
Scope the iframe-height CSS fix to only the actually-embedded tool

### DIFF
--- a/src/main/javascript/src/App.spec.js
+++ b/src/main/javascript/src/App.spec.js
@@ -187,6 +187,28 @@ describe("App", () => {
     expect(localStorage.getItem("terracotta-quiz-draft-1-2")).toBe("{}");
   });
 
+  describe("app--embedded class (see _global.scss's .v-application__wrap override)", () => {
+    const originalTop = window.top;
+
+    afterEach(() => {
+      Object.defineProperty(window, "top", { value: originalTop, configurable: true });
+    });
+
+    it("is not applied to a plain top-level page (e.g. the treatment preview window)", async () => {
+      const { wrapper } = await mountApp();
+
+      expect(wrapper.classes()).not.toContain("app--embedded");
+    });
+
+    it("is applied when embedded in an iframe (the real LTI tool)", async () => {
+      Object.defineProperty(window, "top", { value: {}, configurable: true });
+
+      const { wrapper } = await mountApp();
+
+      expect(wrapper.classes()).toContain("app--embedded");
+    });
+  });
+
   describe("frame resize reporting (lti.frameResize)", () => {
     const originalTop = window.top;
 

--- a/src/main/javascript/src/App.vue
+++ b/src/main/javascript/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app
     :style="appStyle"
+    :class="{ 'app--embedded': isEmbedded }"
     tabindex="0"
   >
     <SkipTo
@@ -226,6 +227,15 @@ const configuration = computed(
 const appStyle = computed(() => {
   return route.meta.appStyle;
 });
+
+// Distinguishes the real embedded LTI tool (where App.vue's own resize reporting
+// resizes an outer iframe to fit, so this app's content should be allowed to be
+// shorter than a full viewport) from a plain top-level page like the treatment
+// preview window (opened via window.open, not embedded - see
+// ExperimentAssignments.vue's handleTreatmentPreview) or /oauth2-redirect, where a
+// normal page filling at least the browser's own viewport is exactly what's wanted.
+// See the .app--embedded rule in _global.scss for the other half of this.
+const isEmbedded = isEmbeddedInAnIframe();
 
 const isIntegration = computed(() => {
   return props.integrationData != null;

--- a/src/main/javascript/src/styles/_global.scss
+++ b/src/main/javascript/src/styles/_global.scss
@@ -38,7 +38,12 @@ body {
 // self-reinforcing instead: body can never report shorter than whatever height the
 // iframe already has, so a short page (e.g. the assignment/message editors) can never
 // shrink the iframe back down, leaving blank space below its real content.
-.v-application__wrap {
+//
+// Scoped to .app--embedded (see App.vue's isEmbedded) - a plain top-level page like
+// the treatment preview window (window.open, not embedded) still wants the normal
+// full-viewport-filling default; removing it there just leaves a short page floating
+// in a mostly-blank browser tab instead of fixing anything.
+.app--embedded .v-application__wrap {
   min-height: unset !important;
 }
 


### PR DESCRIPTION
Removing .v-application__wrap's min-height: 100vh fixed the assignment/ message editors' blank space inside Canvas's iframe, but applied the same override everywhere, including plain top-level pages that were never embedded to begin with - like the treatment preview, which opens in its own browser tab via window.open (see
ExperimentAssignments.vue's handleTreatmentPreview). Those pages still want the normal "fill at least the browser viewport" default; removing it there just left a short page floating in an otherwise-blank tab.

App.vue now tags its root with app--embedded only when window.self !== window.top, and the CSS override is scoped under that class.