### PR TITLE
Fix checkbox/label misalignment in the custom web activity editor

### DIFF
--- a/src/main/javascript/src/views/integrations/ExternalIntegrationEditor.vue
+++ b/src/main/javascript/src/views/integrations/ExternalIntegrationEditor.vue
@@ -680,12 +680,16 @@ div.row-sections {
     min-height: 56px;
   }
 
-  :deep(.v-label:not(.v-field-label--floating)) {
+  // .v-field-label, not the bare .v-label these two rules used to target - a
+  // v-checkbox's own label is a .v-label too (just not a field's), and centering it
+  // this same way (on top of it already being centered by v-selection-control's own
+  // flexbox) shifted it out of alignment with its checkbox icon.
+  :deep(.v-field-label:not(.v-field-label--floating)) {
     top: 50%;
     transform: translateY(-50%);
   }
 
-  :deep(.v-label.v-field-label--floating) {
+  :deep(.v-field-label.v-field-label--floating) {
     top: 10px;
   }
 }


### PR DESCRIPTION
The "Tool allows students to view past submissions" checkbox's label was shifted about half its own height above the checkbox icon. Its vertical-centering rules (top: 50%; transform: translateY(-50%)) were written for this editor's outlined text-field/textarea labels, but targeted the bare .v-label class - the checkbox's own label carries that same class, so it got the same transform on top of already being centered by v-selection-control's own flexbox, throwing it out of alignment with the icon. Scoped the selectors to .v-field-label instead, which only text-field-style inputs carry.