### PR TITLE
Fix infinite iframe growth loop in the student integration quiz view

### DIFF
--- a/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.spec.js
+++ b/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.spec.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { mountComponent } from "@/test-utils/mount";
 import StudentQuizIntegration from "./StudentQuizIntegration.vue";
@@ -33,53 +33,33 @@ describe("StudentQuizIntegration", () => {
   });
 
   describe("fallback height (before a resize message arrives)", () => {
-    const originalInnerHeight = window.innerHeight;
-
-    afterEach(() => {
-      vi.restoreAllMocks();
-      Object.defineProperty(window, "innerHeight", { value: originalInnerHeight, configurable: true });
-    });
-
     // real content height is unknown until the embedded tool posts a resize message
     // (which - see StudentQuizIntegration.vue's own comment - isn't guaranteed to
-    // ever happen at all), so in the meantime the iframe is sized to whatever
-    // viewport space is actually left below it, not a fixed guess.
-    it("sizes the iframe to the remaining viewport space below it", async () => {
+    // ever happen at all), so in the meantime the iframe gets a flat CSS min-height
+    // via the no-resize class, rather than one measured off window.innerHeight - that
+    // measurement isn't independent of this component's own output, since App.vue's
+    // own resize reporting sizes the LMS's outer iframe (this window) off this
+    // document's height, which this fallback itself contributes to. Feeding a
+    // "remaining viewport space" measurement back into the thing driving the
+    // viewport's own size grows without bound.
+    it("does not set an inline height - the no-resize class's flat min-height applies instead", () => {
       const wrapper = mountComponent(StudentQuizIntegration, {
         props: { assessment, integration, hasResizeMessage: false }
       });
 
-      Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
-      vi.spyOn(wrapper.find("iframe").element, "getBoundingClientRect").mockReturnValue({ top: 200 });
-      window.dispatchEvent(new Event("resize"));
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.find("iframe").attributes("style")).toContain("height: 700px");
+      expect(wrapper.find("iframe").attributes("style")).toBeFalsy();
+      expect(wrapper.find("iframe").classes()).toContain("no-resize");
     });
 
-    it("clamps to a sane minimum instead of collapsing when little viewport room is left", async () => {
+    it("still sets no inline height once a resize message has arrived, leaving the embedded tool's own real height in control", async () => {
       const wrapper = mountComponent(StudentQuizIntegration, {
         props: { assessment, integration, hasResizeMessage: false }
       });
-
-      Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
-      vi.spyOn(wrapper.find("iframe").element, "getBoundingClientRect").mockReturnValue({ top: 850 });
-      window.dispatchEvent(new Event("resize"));
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.find("iframe").attributes("style")).toContain("height: 300px");
-    });
-
-    it("clears the inline height once a resize message has arrived, leaving the embedded tool's own real height in control", async () => {
-      const wrapper = mountComponent(StudentQuizIntegration, {
-        props: { assessment, integration, hasResizeMessage: false }
-      });
-
-      expect(wrapper.find("iframe").attributes("style")).toContain("height");
 
       await wrapper.setProps({ hasResizeMessage: true });
 
       expect(wrapper.find("iframe").attributes("style")).toBeFalsy();
+      expect(wrapper.find("iframe").classes()).not.toContain("no-resize");
     });
   });
 

--- a/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.vue
+++ b/src/main/javascript/src/views/student/quiz/components/StudentQuizIntegration.vue
@@ -11,10 +11,8 @@
       <iframe
         v-if="!readonly"
         id="integration-iframe"
-        ref="iframeEl"
         :src="integration.launchUrl"
         :class="{ 'no-resize': !hasResizeMessage }"
-        :style="hasResizeMessage ? {} : { height: `${fallbackHeight}px` }"
         title="student assignment"
         aria-label="student assignment"
       />
@@ -36,7 +34,6 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from "vue";
 import ExternalIntegrationResponseEditor from "@/views/integrations/ExternalIntegrationResponseEditor.vue";
 
 defineProps({
@@ -46,55 +43,6 @@ defineProps({
   submitted: { type: Boolean, default: false },
   selectedSubmission: { type: Object, default: null },
   hasResizeMessage: { type: Boolean, default: false }
-});
-
-const iframeEl = ref(null);
-// a sane guess for the very first paint, before onMounted's real measurement runs -
-// see measureFallbackHeight's own comment for why this can't just be a fixed value
-// generally.
-const fallbackHeight = ref(400);
-let resizeObserver = null;
-
-// Keeps this iframe's own contribution to the page's height bounded to whatever
-// vertical space is actually left below it in the viewport, so the fallback used
-// before the embedded tool posts its real resize message (handleIntegrationsResize in
-// StudentQuiz.vue) can't itself push this document taller than one viewport - which
-// is exactly what caused the double-scrollbar bug a flat CSS min-height had (see this
-// file's git history). A fixed px guess can't adapt to that: how much banner/
-// instruction content renders above this iframe varies (retake banner, submission
-// details, the assessment intro html above), and so does the viewport itself.
-//
-// This matters even more for any integration that never sends a resize message at
-// all - the resize-observer scripts under public/js/integrations/resize/ are
-// something the integration's OWN author has to add on their end; nothing here can
-// assume they did. For those, this isn't a brief loading state, it's the iframe's
-// height for the rest of the session, so it needs to be a reasonable real size, not
-// just "not broken for a moment."
-const measureFallbackHeight = () => {
-  if (!iframeEl.value) {
-    return;
-  }
-
-  const MIN_HEIGHT = 300; // still usable if something above pushes this near/past the fold
-  const top = iframeEl.value.getBoundingClientRect().top;
-
-  fallbackHeight.value = Math.max(window.innerHeight - top, MIN_HEIGHT);
-};
-
-onMounted(() => {
-  measureFallbackHeight();
-  // catches both viewport resizes and layout shifts from content elsewhere on the
-  // page (a banner appearing/disappearing, the assessment intro html rendering) -
-  // observing document.body is broad on purpose, since enumerating every possible
-  // cause of "content above this iframe changed height" isn't practical.
-  resizeObserver = new ResizeObserver(measureFallbackHeight);
-  resizeObserver.observe(document.body);
-  window.addEventListener("resize", measureFallbackHeight);
-});
-
-onBeforeUnmount(() => {
-  resizeObserver?.disconnect();
-  window.removeEventListener("resize", measureFallbackHeight);
 });
 </script>
 
@@ -106,15 +54,8 @@ onBeforeUnmount(() => {
   // its "full-height" layout mode, which this row/col's own min-height: 100% used to
   // resolve against regardless of how much space any PRECEDING sibling content
   // (retake banner, submission details, etc. in StudentQuiz.vue) already used above
-  // it. That's a second, independent way this page's total height could end up
-  // taller than one viewport - confirmed via a standalone reproduction with a
-  // stand-in "banner" div above this component: even with the iframe itself sized
-  // exactly to the remaining viewport space (see measureFallbackHeight's comment
-  // above), this row/col still inflated to a FULL extra viewport-height's worth of
-  // space on top of that banner, because min-height: 100% doesn't know or care what
-  // else is already on the page. Without it, this area sizes to its own content
-  // (the iframe's own height, which is already correctly computed) instead of
-  // fighting it.
+  // it, inflating this area by a full extra viewport's worth of space on top of that.
+  // Without it, this area sizes to its own content instead of fighting it.
   & > .v-col {
     min-width: 100%;
 
@@ -122,21 +63,26 @@ onBeforeUnmount(() => {
       // an iframe defaults to display: inline, which sits it on a text baseline and
       // reserves a few extra px below it for descenders (the same "mystery gap
       // under an image" quirk that comes up whenever an inline-replaced element
-      // sits in a block context) - block avoids that, so this element's own
-      // measured height (see measureFallbackHeight above) is really all the extra
-      // vertical space its container ends up needing.
+      // sits in a block context) - block avoids that.
       display: block;
       min-width: 100%;
       border: none;
     }
   }
 
-  // .no-resize itself carries no height rule any more - the fallback height is set
-  // as an inline style computed by measureFallbackHeight() in the script above (a
-  // fixed CSS value, like the min-height: 100vh this used to be, can't adapt to how
-  // much banner/instruction content is actually rendered above this iframe or to the
-  // viewport size, and reliably guessed wrong in a way that caused a double
-  // scrollbar - see that function's comment). The class stays as a hook for
-  // tests/styling to key off "we don't have a real height yet" if needed.
+  // A fixed fallback, not one measured off window.innerHeight (an earlier version of
+  // this rule did that): App.vue's own resize reporting (notifyParentOfHeight) sizes
+  // the LMS's outer iframe off this document's height, and that outer iframe IS this
+  // window - so window.innerHeight was never an independent measurement, it was
+  // downstream of whatever this very fallback last reported. Each render fed a larger
+  // "remaining space" back into the next one, growing without bound (confirmed live:
+  // the iframe visibly grew every frame until the LMS gave up and let it scroll
+  // internally instead). A flat value can't feed back into itself this way. Safe now
+  // that the old min-height: 100vh double-scrollbar problem this was trying to dodge
+  // is fixed at its source (see .app--embedded in _global.scss) - the LMS's own page
+  // scrolling to fit this height is the intended behavior, not something to avoid.
+  & .no-resize {
+    min-height: 600px;
+  }
 }
 </style>


### PR DESCRIPTION
StudentQuizIntegration's fallback height (used before the embedded tool posts its own resize message) measured window.innerHeight and sized the iframe to fill whatever viewport space was left. That worked when the LMS's outer iframe had a fixed size unrelated to this page's own content. It no longer does: App.vue's own resize reporting (added to fix a different blank-space bug) now sizes that same outer iframe off this document's height, and this fallback is part of that height. Each render's "remaining space" grew the fallback, which grew the document, which grew the outer iframe, which grew window.innerHeight, feeding a larger number into the next render - unbounded growth with no natural ceiling, confirmed live.

Replaced the measured fallback with a flat CSS min-height (matching what this rule used before it was made dynamic) - a constant can't feed back into its own input. The double-scrollbar problem the dynamic version was written to dodge is fixed at its source now (see .app--embedded in _global.scss), so a flat value is safe again: the LMS's own page scrolling to fit this height is the intended behavior.